### PR TITLE
abstract algebra: draft of structures section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,10 @@
 *.fls
 *.log
 *.synctex.gz
+src/
 source/01_Introduction/
 source/02_Basics/
 source/03_Logic/
 source/04_Sets_and_Functions/
 source/05_Number_Theory/
+source/06_Abstract_Algebra/

--- a/lean_source/01_Introduction/source_01_Getting_Started.lean
+++ b/lean_source/01_Introduction/source_01_Getting_Started.lean
@@ -50,7 +50,7 @@ book in a VS Code window. You can update to a newer version by tying
 the ``mathematics_in_lean`` folder.
 
 Alternatively, you can run Lean and VS Code in the cloud,
-using `Gitpod <https://gitpod.io/>`.
+using `Gitpod <https://gitpod.io/>`_.
 You can find instructions as to how to do that on the Mathematics in Lean
 `project page <https://github.com/leanprover-community/mathematics_in_lean>`_
 on Github.

--- a/lean_source/06_Abstract_Algebra/source_01_Structures.lean
+++ b/lean_source/06_Abstract_Algebra/source_01_Structures.lean
@@ -1,0 +1,503 @@
+import algebra.big_operators.ring
+import data.real.basic
+
+/- TEXT:
+
+.. _section_structures:
+
+Structures
+----------
+
+In the broadest sense of the term, a *structure* is a specification
+of a collection of data, possibly with contraints that the
+data is required to satisfy.
+An *instance* of the structure is a particular bundle of data satisfying
+the constraints. For example, we can specify that a point is
+a tuple of three real numbers:
+BOTH: -/
+-- QUOTE:
+@[ext] structure point := (x : ℝ) (y : ℝ) (z : ℝ)
+-- QUOTE.
+
+/- TEXT:
+The ``@[ext]`` annotation tells Lean to automatically generate theorems
+that can be used to prove that two instances of a structure are equal
+when their components are equal.
+EXAMPLES: -/
+-- QUOTE:
+#check point.ext
+
+example (a b : point) (hx : a.x = b.x) (hy : a.y = b.y) (hz : a.z = b.z) :
+  a = b :=
+begin
+  ext,
+  repeat { assumption }
+end
+-- QUOTE.
+
+/- TEXT:
+We can then define particular instances of the ``point`` structure.
+Lean provides multiple ways of doing that.
+EXAMPLES: -/
+-- QUOTE:
+def my_point1 : point :=
+{ x := 2,
+  y := -1,
+  z := 4 }
+
+def my_point2 :=
+{ point .
+  x := 2,
+  y := -1,
+  z := 4 }
+
+def my_point3 : point := ⟨2, -1, 4⟩
+
+def my_point4 := point.mk 2 (-1) 4
+-- QUOTE.
+
+/- TEXT:
+In the first two examples, the fields of the structure are named
+explicitly.
+In the first case, because Lean knows that the expected type of
+``my_point1`` is a ``point``, you can start the definition by
+writing ``{! !}``. Clicking on the light bulb
+that appears nearby in VS Code will then
+give you the option of inserting a template definition
+with the field names listed for you.
+
+By default, the *constructor* for the ``point`` structure is named
+``point.mk``. You can specify a different name if you want.
+EXAMPLES: -/
+-- QUOTE:
+structure point' := build :: (x : ℝ) (y : ℝ) (z : ℝ)
+
+#check point'.build 2 (-1) 4
+-- QUOTE.
+
+/- TEXT:
+The next two examples show how to define functions
+on structures using pattern matching.
+Whereas the second example makes the ``point.mk``
+constructor explicit, the first example uses anonymous constructors
+for brevity.
+Lean can infer the relevant constructor from the indicated type of
+``add``.
+It is conventional to put definitions and theorems associated
+with a structure like ``point`` in a namespace with the same name.
+In the example below, the full name of ``add`` is ``point.add``,
+which allows us to use the anonymous projection notation.
+BOTH: -/
+-- QUOTE:
+namespace point
+
+def add : point → point → point
+| ⟨x₁, y₁, z₁⟩ ⟨x₂, y₂, z₂⟩ := ⟨x₁ + x₂, y₁ + y₂, z₁ + z₂⟩
+
+-- EXAMPLES:
+def add' : point → point → point
+| (point.mk x₁ y₁ z₁) (point.mk x₂ y₂ z₂) :=
+  { x := x₁ + x₂,
+    y := y₁ + y₂,
+    z := z₁ + z₂ }
+
+#check add my_point1 my_point2
+#check my_point1.add my_point2
+
+end point
+
+#check point.add my_point1 my_point2
+#check my_point1.add my_point2
+-- QUOTE.
+
+/- TEXT:
+Below we will continue to put definitions in the relevant
+namespace, but we will leave the namespacing commands out of the quoted
+snippets.
+
+Within a proof, structures can be decomposed with the ``cases`` or ``rcases``
+tactics. You can also use ``rintros`` or a pattern-matching
+lambda.
+
+EXAMPLES: -/
+namespace point
+
+-- QUOTE:
+theorem add_comm (a b : point) : add a b = add b a :=
+begin
+  cases a with xa ya za,
+  cases b with xb yb zb,
+  rw [add, add],
+  ext; dsimp,
+  repeat { apply add_comm }
+end
+
+example (a b : point) : add a b = add b a :=
+begin
+  rcases a with ⟨xa, ya, za⟩,
+  rcases b with ⟨xb, yb, zb⟩,
+  simp [add, add_comm]
+end
+
+example : ∀ a b : point, add a b = add b a :=
+begin
+  rintros ⟨xa, ya, za⟩ ⟨xb, yb, zb⟩,
+  simp [add, add_comm]
+end
+
+example : ∀ a b : point, add a b = add b a :=
+λ ⟨xa, ya, za⟩ ⟨xb, yb, zb⟩, by simp [add, add_comm]
+-- QUOTE.
+
+/- TEXT:
+In fact, even proving that the addition function does
+the right thing on the ``x`` coordinate
+requires decomposing the instances with ``cases``.
+EXAMPLES: -/
+-- QUOTE:
+theorem add_x (a b : point) : (a.add b).x = a.x + b.x :=
+by { cases a, cases b, refl }
+-- QUOTE.
+
+/- TEXT:
+Starting a proof with ``cases`` is a common pattern when dealing with functions
+that were defined by pattern matching.
+An alternative is to define functions using projections,
+in which case, the relevant equations often hold definitionally.
+EXAMPLES: -/
+-- QUOTE:
+def add'' (a b : point) : point := ⟨a.x + b.x, a.y + b.y, a.z + b.z⟩
+
+theorem add''_x (a b : point) : (a.add'' b).x = a.x + b.x := rfl
+-- QUOTE.
+
+/- TEXT:
+Mathematical constructions often involve taking apart bundled information and
+putting it together again in different ways.
+It therefore makes sense that Lean and mathlib offer so many ways
+of doing this efficiently.
+As an exercise, try proving that ``point.add`` is associative.
+Then define scalar multiplication for a point and show that it
+distributes over addition.
+You can use pattern matching or projections in the definition,
+as you prefer.
+BOTH: -/
+-- QUOTE:
+theorem add_assoc (a b c : point) : (a.add b).add c = a.add (b.add c) :=
+/- EXAMPLES:
+sorry
+SOLUTIONS: -/
+by { cases a, cases b, cases c, simp [add, add_assoc] }
+-- BOTH:
+
+/- EXAMPLES:
+def smul (r : ℝ) : point → point := sorry
+SOLUTIONS: -/
+def smul (r : ℝ) : point → point
+| ⟨x, y, z⟩ := ⟨r * x, r * y, r * z⟩
+-- BOTH:
+
+theorem smul_distrib (r : ℝ) (a b : point) :
+  (smul r a).add (smul r b) = smul r (a.add b) :=
+/- EXAMPLES:
+sorry
+SOLUTIONS: -/
+by { cases a, cases b, simp [add, smul, mul_add] }
+-- BOTH:
+-- QUOTE.
+
+end point
+
+/- TEXT:
+Using structures is only the first step on the road to
+algebraic abstraction.
+We don't yet have a way to link ``point.add`` to the generic ``+`` symbol,
+or to connect ``point.add_comm`` and ``point.add_assoc`` to
+the generic ``add_comm`` and ``add_assoc`` theorems.
+These tasks belong to the *algebraic* aspect of using structures,
+and we will explain how to do carry them out in the next section.
+For now, just think of a structure as a way of bundling together objects
+and information.
+
+It is especially useful that a structure can specify not only
+data types but also constraints that the data must satisfy.
+In Lean, the latter are represented as fields of type ``Prop``.
+For example, the *standard 2-simplex* is defined to be the set of
+points :math:`(x, y, z)` satisfying :math:`x ≥ 0`, :math:`y ≥ 0`, :math:`z ≥ 0`,
+and :math:`x + y + z = 1`.
+If you are not familiar with the notion, you should draw a picture,
+and convince yourself that this set is
+the equilateral triangle in three-space with vertices
+:math:`(1, 0, 0)`, :math:`(0, 1, 0)`, and :math:`(0, 0, 1)`,
+together with its interior.
+We can represent it in Lean as follows:
+BOTH: -/
+-- QUOTE:
+structure standard_two_simplex :=
+(x : ℝ)
+(y : ℝ)
+(z : ℝ)
+(x_nonneg : 0 ≤ x)
+(y_nonneg : 0 ≤ y)
+(z_nonneg : 0 ≤ z)
+(sum_eq   : x + y + z = 1)
+-- QUOTE.
+
+/- TEXT:
+Notice that the last four fields refer to ``x``, ``y``, and ``z``,
+that is, the first three fields.
+We can define a map from the two-simplex to itself that swaps ``x`` and ``y``:
+BOTH: -/
+namespace standard_two_simplex
+
+-- EXAMPLES:
+-- QUOTE:
+def swap_xy : standard_two_simplex → standard_two_simplex
+| ⟨x, y, z, xnn, ynn, znn, hsum⟩ :=
+  { x := y,
+    y := x,
+    z := z,
+    x_nonneg := ynn,
+    y_nonneg := xnn,
+    z_nonneg := znn,
+    sum_eq   := by rwa add_comm y x }
+-- QUOTE.
+
+/- TEXT:
+More interestingly, we can compute the midpoint of two points on
+the simplex. We need to add ``noncomputable theory`` in order to
+use division on the real numbers.
+BOTH: -/
+-- QUOTE:
+noncomputable theory
+
+-- EXAMPLES:
+def midpoint : standard_two_simplex → standard_two_simplex → standard_two_simplex
+| ⟨x1, y1, z1, xnn1, ynn1, znn1, hsum1⟩ ⟨x2, y2, z2, xnn2, ynn2, znn2, hsum2⟩ :=
+  { x        := (x1 + x2) / 2,
+    y        := (y1 + y2) / 2,
+    z        := (z1 + z2) / 2,
+    x_nonneg := div_nonneg (add_nonneg xnn1 xnn2) (by norm_num),
+    y_nonneg := div_nonneg (add_nonneg ynn1 ynn2) (by norm_num),
+    z_nonneg := div_nonneg (add_nonneg znn1 znn2) (by norm_num),
+    sum_eq   := by { field_simp, linarith } }
+-- QUOTE.
+
+/- TEXT:
+Here we have established ``x_nonneg``, ``y_nonneg``, and ``z_nonneg``
+with concise proof terms, but establish ``sum_eq`` in tactic mode,
+using ``by``. You can just as well use a ``begin ... end`` block
+for that purpose.
+
+Given a parameter :math:`\lambda` satisfying :math:`0 \le \lambda \le 1`,
+we can take the weighted average :math:`\lambda a + (1 - \lambda) b`
+of two points :math:`a` and :math:`b` in the standard 2-simplex.
+We challenge you to define that function, in analogy to the ``midpoint``
+function above.
+Onec again, you can use pattern matching or projections, as you prefer.
+BOTH: -/
+-- QUOTE:
+def weighted_average (lambda : real)
+    (lambda_nonneg : 0 ≤ lambda) (lambda_le : lambda ≤ 1)  :
+/- EXAMPLES:
+  standard_two_simplex → standard_two_simplex → standard_two_simplex := sorry
+SOLUTIONS: -/
+  standard_two_simplex → standard_two_simplex → standard_two_simplex
+| ⟨x1, y1, z1, xnn1, ynn1, znn1, hsum1⟩ ⟨x2, y2, z2, xnn2, ynn2, znn2, hsum2⟩ :=
+  { x        := lambda * x1 + (1 - lambda) * x2,
+    y        := lambda * y1 + (1 - lambda) * y2,
+    z        := lambda * z1 + (1 - lambda) * z2,
+    x_nonneg := add_nonneg (mul_nonneg lambda_nonneg xnn1)
+                  (mul_nonneg (by linarith) xnn2),
+    y_nonneg := add_nonneg (mul_nonneg lambda_nonneg ynn1)
+                  (mul_nonneg (by linarith) ynn2),
+    z_nonneg := add_nonneg (mul_nonneg lambda_nonneg znn1)
+                  (mul_nonneg (by linarith) znn2),
+    sum_eq   :=
+      begin
+        transitivity (x1 + y1 + z1) * lambda + (x2 + y2 + z2) * (1 - lambda),
+        { ring },
+        simp [hsum1, hsum2]
+      end }
+-- QUOTE.
+-- BOTH:
+
+end standard_two_simplex
+
+/- TEXT:
+Structures can depend on parameters.
+For example, we can generalize the standard 2-simplex to the standard
+:math:`n`-simplex for any :math:`n`.
+At this stage, you don't have to know anything about the type `fin n`
+except that it has :math:`n` elements, and that Lean knows
+how to sum over it.
+BOTH: -/
+-- QUOTE:
+open_locale big_operators
+
+structure standard_simplex (n : ℕ) :=
+(v          : fin n → ℝ)
+(nonneg     : ∀ i : fin n, 0 ≤ v i)
+(sum_eq_one : ∑ i, v i = 1)
+
+namespace standard_simplex
+
+def midpoint (n : ℕ): standard_simplex n → standard_simplex n → standard_simplex n
+| ⟨v1, nonneg1, sum1⟩ ⟨v2, nonneg2, sum2⟩ :=
+  { v := λ i, (v1 i + v2 i) / 2,
+    nonneg :=
+      begin
+        intro i,
+        apply div_nonneg,
+        { linarith [nonneg1 i, nonneg2 i] },
+        norm_num
+      end,
+    sum_eq_one :=
+    begin
+      simp [div_eq_mul_inv, ←finset.sum_mul, finset.sum_add_distrib,
+        sum1, sum2],
+      field_simp
+    end  }
+
+end standard_simplex
+-- QUOTE.
+
+/- TEXT:
+As an exercise, see if you can define the weighted average of
+two points in the standard :math:`n`-simplex.
+You can use ``finset.sum_add_distrib``
+and ``finset.mul_sum`` to manipulate the relevant sums.
+
+SOLUTIONS: -/
+namespace standard_simplex
+
+def weighted_average {n : ℕ} (lambda : real)
+    (lambda_nonneg : 0 ≤ lambda) (lambda_le : lambda ≤ 1)  :
+  standard_simplex n → standard_simplex n → standard_simplex n
+| ⟨v1, nonneg1, sum1⟩ ⟨v2, nonneg2, sum2⟩ :=
+  { v        := λ i, lambda * v1 i + (1 - lambda) * v2 i,
+    nonneg   := λ i, add_nonneg (mul_nonneg lambda_nonneg (nonneg1 i))
+                  (mul_nonneg (by linarith) (nonneg2 i)),
+    sum_eq_one :=
+      begin
+        transitivity lambda * (∑ i, v1 i) + (1 - lambda) * (∑ i, v2 i),
+        { rw [finset.sum_add_distrib, finset.mul_sum, finset.mul_sum] },
+        simp [sum1, sum2]
+      end }
+
+end standard_simplex
+
+/- TEXT:
+We have seen that structures can be used to bundle together data
+and properties.
+Interestingly, they can also be used to bundle together properties
+without the data.
+For example, the next structure, ``is_linear``, bundles together
+the two components of linearity.
+EXAMPLES: -/
+-- QUOTE:
+structure is_linear (f : ℝ → ℝ) :=
+(is_additive : ∀ x y, f (x + y) = f x + f y)
+(preserves_mul : ∀ x c, f (c * x) = c * f x)
+
+section
+variables (f : ℝ → ℝ) (linf : is_linear f)
+
+#check linf.is_additive
+#check linf.preserves_mul
+
+end
+-- QUOTE.
+
+/- TEXT:
+It is worth pointing out that structures are not the only way to bundle
+together data.
+The ``point`` data structure can be defined using the generic type product,
+and ``is_linear`` can be defined with a simple ``and``.
+EXAMPLES: -/
+-- QUOTE:
+def point'' := ℝ × ℝ × ℝ
+
+def is_linear' (f : ℝ → ℝ) :=
+(∀ x y, f (x + y) = f x + f y) ∧ (∀ x c, f (c * x) = c * f x)
+-- QUOTE.
+
+/- TEXT:
+Generic type constructions can even be used in place of structures
+with dependencies between their components.
+For example, the *subtype* construction combines a piece of data with
+a property.
+You can think of of the type ``preal`` in the next example as being
+the type of positive real numbers.
+Any ``x : preal`` has two components: the value, and the property of being
+positive.
+You can access these components as ``x.val``, which has type ``ℝ``,
+and ``x.property``, which represents the fact ``0 < x.val``.
+EXAMPLES: -/
+-- QUOTE:
+def preal := { y : ℝ // 0 < y }
+
+section
+variable x : preal
+
+#check x.val
+#check x.property
+
+#check x.1
+#check x.2
+
+end
+-- QUOTE.
+
+/- TEXT:
+We could have used subtypes to define the standard 2-simplex,
+as well as the standard :math:`n`-simplex for an arbitrary :math:`n`.
+EXAMPLES: -/
+-- QUOTE:
+def standard_two_simplex' :=
+{ p : ℝ × ℝ × ℝ // 0 ≤ p.1 ∧ 0 ≤ p.2.1 ∧ 0 ≤ p.2.2 ∧ p.1 + p.2.1 + p.2.2 = 1 }
+
+def standard_simplex' (n : ℕ) :=
+{ v : fin n → ℝ // (∀ i : fin n, 0 ≤ v i) ∧ (∑ i, v i = 1) }
+-- QUOTE.
+
+/- TEXT:
+Similarly, *Sigma types* are generalizations of ordered pairs,
+whereby the type of the second component depends on the type of
+the first.
+EXAMPLES: -/
+-- QUOTE:
+def std_simplex := Σ n : ℕ, standard_simplex n
+
+section
+variable s : std_simplex
+
+#check s.fst
+#check s.snd
+
+#check s.1
+#check s.2
+
+end
+-- QUOTE.
+
+/- TEXT:
+Given ``s : std_simplex``, the first component ``s.fst`` is a natural
+number, and the second component is an element of the corresponding
+simplex ``standard_simplex s.fst``.
+The difference between a Sigma type and a subtype is that
+the second component of a Sigma type is data rather than a proposition.
+
+But even though we can use products, subtypes, and Sigma types
+instead of structures, using structures has a number of advantages.
+Defining a structure abstracts away the underlying representation
+and provides custom names for the functions that access the components.
+This makes proofs more robust:
+proofs that rely only on the interface to a structure
+will generally continue to work when we change the definition,
+as long as we redefine the old accessors in terms of the new definition.
+Moreover, as we are about to see, Lean provides support for
+weaving structures together into a rich, interconnected hierarchy,
+and for managing the interactions between them.
+TEXT. -/
+

--- a/lean_source/06_Abstract_Algebra/source_01_Structures.lean
+++ b/lean_source/06_Abstract_Algebra/source_01_Structures.lean
@@ -96,13 +96,13 @@ BOTH: -/
 -- QUOTE:
 namespace point
 
--- EXAMPLES:
 def add (a b : point) : point := ⟨a.x + b.x, a.y + b.y, a.z + b.z⟩
 
+-- EXAMPLES:
 def add' (a b : point) : point :=
-  { x := a.x + b.x,
-    y := a.y + b.y,
-    z := a.z + b.z }
+{ x := a.x + b.x,
+  y := a.y + b.y,
+  z := a.z + b.z }
 
 #check add my_point1 my_point2
 #check my_point1.add my_point2
@@ -207,22 +207,21 @@ of doing this efficiently.
 As an exercise, try proving that ``point.add`` is associative.
 Then define scalar multiplication for a point and show that it
 distributes over addition.
-You can use pattern matching or projections in the definition,
-as you prefer.
 BOTH: -/
 -- QUOTE:
-protected theorem add_assoc (a b c : point) : (a.add b).add c = a.add (b.add c) :=
+protected theorem add_assoc (a b c : point) :
+  (a.add b).add c = a.add (b.add c) :=
 /- EXAMPLES:
 sorry
 SOLUTIONS: -/
-by { cases a, cases b, cases c, simp [add, add_assoc] }
+by { simp [add, add_assoc] }
 -- BOTH:
 
+def smul (r : ℝ) (a : point) : point :=
 /- EXAMPLES:
-def smul (r : ℝ) : point → point := sorry
+sorry
 SOLUTIONS: -/
-def smul (r : ℝ) : point → point
-| ⟨x, y, z⟩ := ⟨r * x, r * y, r * z⟩
+⟨r * a.x, r * a.y, r * a.z⟩
 -- BOTH:
 
 theorem smul_distrib (r : ℝ) (a b : point) :
@@ -230,7 +229,7 @@ theorem smul_distrib (r : ℝ) (a b : point) :
 /- EXAMPLES:
 sorry
 SOLUTIONS: -/
-by { cases a, cases b, simp [add, smul, mul_add] }
+by { simp [add, smul, mul_add] }
 -- BOTH:
 -- QUOTE.
 
@@ -280,15 +279,14 @@ namespace standard_two_simplex
 
 -- EXAMPLES:
 -- QUOTE:
-def swap_xy : standard_two_simplex → standard_two_simplex
-| ⟨x, y, z, xnn, ynn, znn, hsum⟩ :=
-  { x := y,
-    y := x,
-    z := z,
-    x_nonneg := ynn,
-    y_nonneg := xnn,
-    z_nonneg := znn,
-    sum_eq   := by rwa add_comm y x }
+def swap_xy (a : standard_two_simplex) : standard_two_simplex :=
+{ x := a.y,
+  y := a.x,
+  z := a.z,
+  x_nonneg := a.y_nonneg,
+  y_nonneg := a.x_nonneg,
+  z_nonneg := a.z_nonneg,
+  sum_eq   := by rw [add_comm a.y a.x, a.sum_eq] }
 -- QUOTE.
 
 -- OMIT: (TODO) add a link when we have a good explanation of noncomputable theory.
@@ -301,15 +299,14 @@ BOTH: -/
 noncomputable theory
 
 -- EXAMPLES:
-def midpoint : standard_two_simplex → standard_two_simplex → standard_two_simplex
-| ⟨x1, y1, z1, xnn1, ynn1, znn1, hsum1⟩ ⟨x2, y2, z2, xnn2, ynn2, znn2, hsum2⟩ :=
-  { x        := (x1 + x2) / 2,
-    y        := (y1 + y2) / 2,
-    z        := (z1 + z2) / 2,
-    x_nonneg := div_nonneg (add_nonneg xnn1 xnn2) (by norm_num),
-    y_nonneg := div_nonneg (add_nonneg ynn1 ynn2) (by norm_num),
-    z_nonneg := div_nonneg (add_nonneg znn1 znn2) (by norm_num),
-    sum_eq   := by { field_simp, linarith } }
+def midpoint (a b : standard_two_simplex) : standard_two_simplex :=
+{ x        := (a.x + b.x) / 2,
+  y        := (a.y + b.y) / 2,
+  z        := (a.z + b.z) / 2,
+  x_nonneg := div_nonneg (add_nonneg a.x_nonneg b.x_nonneg) (by norm_num),
+  y_nonneg := div_nonneg (add_nonneg a.y_nonneg b.y_nonneg) (by norm_num),
+  z_nonneg := div_nonneg (add_nonneg a.z_nonneg b.z_nonneg) (by norm_num),
+  sum_eq   := by { field_simp, linarith [a.sum_eq, b.sum_eq]} }
 -- QUOTE.
 
 /- TEXT:
@@ -323,31 +320,30 @@ we can take the weighted average :math:`\lambda a + (1 - \lambda) b`
 of two points :math:`a` and :math:`b` in the standard 2-simplex.
 We challenge you to define that function, in analogy to the ``midpoint``
 function above.
-Once again, you can use pattern matching or projections, as you prefer.
 BOTH: -/
 -- QUOTE:
 def weighted_average (lambda : real)
-    (lambda_nonneg : 0 ≤ lambda) (lambda_le : lambda ≤ 1)  :
+    (lambda_nonneg : 0 ≤ lambda) (lambda_le : lambda ≤ 1)
+    (a b : standard_two_simplex) :
+  standard_two_simplex :=
 /- EXAMPLES:
-  standard_two_simplex → standard_two_simplex → standard_two_simplex := sorry
+sorry
 SOLUTIONS: -/
-  standard_two_simplex → standard_two_simplex → standard_two_simplex
-| ⟨x1, y1, z1, xnn1, ynn1, znn1, hsum1⟩ ⟨x2, y2, z2, xnn2, ynn2, znn2, hsum2⟩ :=
-  { x        := lambda * x1 + (1 - lambda) * x2,
-    y        := lambda * y1 + (1 - lambda) * y2,
-    z        := lambda * z1 + (1 - lambda) * z2,
-    x_nonneg := add_nonneg (mul_nonneg lambda_nonneg xnn1)
-                  (mul_nonneg (by linarith) xnn2),
-    y_nonneg := add_nonneg (mul_nonneg lambda_nonneg ynn1)
-                  (mul_nonneg (by linarith) ynn2),
-    z_nonneg := add_nonneg (mul_nonneg lambda_nonneg znn1)
-                  (mul_nonneg (by linarith) znn2),
-    sum_eq   :=
-      begin
-        transitivity (x1 + y1 + z1) * lambda + (x2 + y2 + z2) * (1 - lambda),
-        { ring },
-        simp [hsum1, hsum2]
-      end }
+{ x        := lambda * a.x + (1 - lambda) * b.x,
+  y        := lambda * a.y + (1 - lambda) * b.y,
+  z        := lambda * a.z + (1 - lambda) * b.z,
+  x_nonneg := add_nonneg (mul_nonneg lambda_nonneg a.x_nonneg)
+                (mul_nonneg (by linarith) b.x_nonneg),
+  y_nonneg := add_nonneg (mul_nonneg lambda_nonneg a.y_nonneg)
+                (mul_nonneg (by linarith) b.y_nonneg),
+  z_nonneg := add_nonneg (mul_nonneg lambda_nonneg a.z_nonneg)
+                (mul_nonneg (by linarith) b.z_nonneg),
+  sum_eq   :=
+    begin
+      transitivity (a.x + a.y + a.z) * lambda + (b.x + b.y + b.z) * (1 - lambda),
+      { ring },
+      simp [a.sum_eq, b.sum_eq]
+    end }
 -- QUOTE.
 -- BOTH:
 
@@ -371,20 +367,19 @@ structure standard_simplex (n : ℕ) :=
 
 namespace standard_simplex
 
-def midpoint (n : ℕ): standard_simplex n → standard_simplex n → standard_simplex n
-| ⟨v1, nonneg1, sum1⟩ ⟨v2, nonneg2, sum2⟩ :=
-  { v := λ i, (v1 i + v2 i) / 2,
-    nonneg :=
-      begin
-        intro i,
-        apply div_nonneg,
-        { linarith [nonneg1 i, nonneg2 i] },
-        norm_num
-      end,
-    sum_eq_one :=
+def midpoint (n : ℕ) (a b : standard_simplex n) : standard_simplex n :=
+{ v := λ i, (a.v i + b.v i) / 2,
+  nonneg :=
+    begin
+      intro i,
+      apply div_nonneg,
+      { linarith [a.nonneg i, b.nonneg i] },
+      norm_num
+    end,
+  sum_eq_one :=
     begin
       simp [div_eq_mul_inv, ←finset.sum_mul, finset.sum_add_distrib,
-        sum1, sum2],
+        a.sum_eq_one, b.sum_eq_one],
       field_simp
     end  }
 
@@ -401,18 +396,17 @@ SOLUTIONS: -/
 namespace standard_simplex
 
 def weighted_average {n : ℕ} (lambda : real)
-    (lambda_nonneg : 0 ≤ lambda) (lambda_le : lambda ≤ 1)  :
-  standard_simplex n → standard_simplex n → standard_simplex n
-| ⟨v1, nonneg1, sum1⟩ ⟨v2, nonneg2, sum2⟩ :=
-  { v        := λ i, lambda * v1 i + (1 - lambda) * v2 i,
-    nonneg   := λ i, add_nonneg (mul_nonneg lambda_nonneg (nonneg1 i))
-                  (mul_nonneg (by linarith) (nonneg2 i)),
-    sum_eq_one :=
-      begin
-        transitivity lambda * (∑ i, v1 i) + (1 - lambda) * (∑ i, v2 i),
-        { rw [finset.sum_add_distrib, finset.mul_sum, finset.mul_sum] },
-        simp [sum1, sum2]
-      end }
+    (lambda_nonneg : 0 ≤ lambda) (lambda_le : lambda ≤ 1)
+    (a b : standard_simplex n) : standard_simplex n :=
+{ v          := λ i, lambda * a.v i + (1 - lambda) * b.v i,
+  nonneg     := λ i, add_nonneg (mul_nonneg lambda_nonneg (a.nonneg i))
+                  (mul_nonneg (by linarith) (b.nonneg i)),
+  sum_eq_one :=
+    begin
+      transitivity lambda * (∑ i, a.v i) + (1 - lambda) * (∑ i, b.v i),
+      { rw [finset.sum_add_distrib, finset.mul_sum, finset.mul_sum] },
+      simp [a.sum_eq_one, b.sum_eq_one]
+    end }
 
 end standard_simplex
 

--- a/lean_source/06_Abstract_Algebra/source_01_Structures.lean
+++ b/lean_source/06_Abstract_Algebra/source_01_Structures.lean
@@ -67,7 +67,7 @@ with the field names listed for you.
 
 The function ``point.mk`` referred to in the definition of ``my_point4``
 is known as the *constructor* for the ``point`` structure, because
-it serves to construct instances.
+it serves to construct elements.
 You can specify a different name if you want, like ``build``.
 EXAMPLES: -/
 -- QUOTE:

--- a/lean_source/06_Abstract_Algebra/source_02_Algebraic_Structures.lean
+++ b/lean_source/06_Abstract_Algebra/source_02_Algebraic_Structures.lean
@@ -225,7 +225,7 @@ variables (f : α ≃ β) (g : β ≃ γ)
 Notice the creative naming of the last three constructions. We think of the
 identity function ``equiv.refl``, the inverse operation ``equiv.symm``,
 and the composition operation ``equiv.trans`` as explicit evidence
-that ``equiv`` is an equivalence relation.
+that the property of being in bijective correspondence is an equivalence relation.
 
 Notice also that ``f.trans g`` requires composing the forward functions
 in reverse order. Mathlib has declared a *coercion* from ``equiv α β``
@@ -407,9 +407,9 @@ The magic is achieved with a combination of three things.
 
 #. *Logic.* A definition that should be interpreted in any group takes, as
    arguments, the type of the group and the group structure as arguments.
-   Similarly, a theorem
-   that holds of any group begins with universal quantifiers over
-   the type the of group and the group structure.
+   Similarly, a theorem about the elements of an arbitrary group
+   begins with universal quantifiers over
+   the type of the group and the group structure.
 
 #. *Implicit arguments.* The arguments for the type and the structure
    are generally left implicit, so that we do not have to write them
@@ -434,7 +434,7 @@ we generally do not need to refer to them explicitly,
 Lean allows us to write ``[group G]`` and leave the name anonymous.
 You have probably already noticed that Lean chooses names like ``_inst_1``
 automatically.
-When we use the square-bracket annotation with the ``variables`` command,
+When we use the anonymous square-bracket annotation with the ``variables`` command,
 then as long as the variables are still in scope,
 Lean automatically adds the argument ``[group G]`` to any definition or
 theorem that mentions ``G``.

--- a/lean_source/06_Abstract_Algebra/source_02_Algebraic_Structures.lean
+++ b/lean_source/06_Abstract_Algebra/source_02_Algebraic_Structures.lean
@@ -1,0 +1,674 @@
+import data.real.basic
+
+/- TEXT:
+.. _section_algebraic_structures:
+
+Algebraic Structures
+--------------------
+
+To clarify what we mean by the phrase *algebraic structure*,
+it will help to consider some examples.
+
+#. A *partially ordered set* consists of a set :math:`P` and
+   a binary relation :math:`\le` on :math:`P` that is transitive
+   and antireflexive.
+
+#. A *group* consists of a set :math:`G` with an associative
+   binary operation, an identity element
+   :math:`1`, and a function :math:`g \mapsto g^{-1}` that returns
+   an inverse for each :math:`g` in :math:`G`.
+   A group is *abelian* or *commutative* if the operation is commutative.
+
+#. A *lattice* is a partially ordered set with meets and joins.
+
+#. A *ring* consists of an (addively written) abelian group
+   :math:`(R, +, 0, x \mapsto -x)`
+   together with an associative multiplication operation
+   :math:`\cdot` and an identity :math:`1`,
+   such that multiplication distributes over addition.
+   A ring is *commutative* if the multiplication is commutative.
+
+#. An *ordered ring* :math:`(R, +, 0, -, \cdot, 1, \le)` consists of a ring
+   together with a partial order on its elements, such that `a \le b` implies
+   :math:`a + c \le b + c` for every :math:`a`, :math:`b`, and :math:`c` in :math:`R`,
+   and :math:`0 \le a` and :math:`0 \le b` implies :math:`0 \le a b` for
+   every :math:`a` and :math:`b` in :math:`R`.
+
+#. A *metric space* consists of a set :math:`X` and a function
+   :math:`d : X \times X \to \mathbb{R}` such that the following hold:
+
+   - :math:`d(x, y) \ge 0` for every :math:`x` and :math:`y` in :math:`X`.
+   - :math:`d(x, y) = 0` if and only if :math:`x = y`.
+   - :math:`d(x, y) = d(y, x)` for every :math:`x` and :math:`y` in :math:`X`.
+   - :math:`d(x, z) \le d(x, y) + d(y, z)` for every :math:`x`, :math:`y`, and
+     :math:`z` in :math:`X`.
+
+#. A *topological space* consists of a set :math:`X` and a collection :math:`\mathcal T`
+   of subsets of :math:`X`, called the *open subsets of* :math:`X`, such that
+   the following hold:
+
+   - The empty set is open.
+   - The intersection of two open sets is open.
+   - An arbitrary union of open sets is open.
+
+In each of these examples, the elements of the structure belong to a
+set, the *carrier set*,
+that sometimes stands proxy for the entire structure.
+For example, when we say "let :math:`G` be a group" and then
+"let :math:`g \in G`," we are using :math:`G` to stand for both
+the structure and its carrier.
+Not every algebraic structure is associated with a single carrier set in this way.
+For example, a *bipartite graph* involves a relation between two sets,
+as does a *Galois connection*,
+A *category* also involves two sets of interest, commonly called the *objects*
+and the *morphisms*.
+
+The examples indicate some of the things that a proof assistant has to do
+in order to support algebraic reasoning.
+First, it needs to recognize concrete instances of structures.
+The number systems :math:`\mathbb{Z}`, :math:`\mathbb{Q}`,
+and :math:`\mathbb{R}` are all ordered rings,
+and we should be able to apply a generic theorem about ordered rings
+in any of these instances.
+Sometimes a concrete set may the an instance of a structure in more than one way.
+For example, in addition to the usual topology on :math:`\mathbb{R}`,
+which forms the basis for real analysis,
+we can also consider the *discrete* topology on :math:`\mathbb{R}`,
+in which every set is open.
+
+Second, a proof assistant needs to support generic notation on structures.
+In Lean, the notation ``*``
+is used for multiplication in all the usual number systems,
+as well as for multiplication in generic groups and rings.
+When we use an expression like ``f x * y``,
+Lean has to use information about the types of ``f``, ``x``, and ``y``
+to determine which multiplication we have in mind.
+
+Third, it needs to deal with the fact that structures can inherit
+definitions, theorems, and notation from other structures in various ways.
+Some structures extend others by adding more axioms.
+A commutative ring is still a ring, so any definition
+that makes sense in a ring also makes sense in a commutative ring,
+and any theorem that holds in a ring also holds in a commutative ring.
+Some structures extend others by adding more data.
+For example, the additive part of any ring is an additive group.
+The ring structure adds a multiplication and an identity,
+as well as axioms that govern them and relate them to the additive part.
+Sometimes we can define one structure in terms of another.
+Any metric space has a canonical topology associated with it,
+the *metric space topology*, and there are various topologies that can be
+associated with any linear ordering.
+
+Finally, it is important to keep in mind that mathematics allows us to
+use functions and operations to define structures in the same way we
+use functions and operations to define numbers.
+Products and powers of groups are again groups.
+For every :math:`n`, the integers modulo :math:`n` form a ring,
+and for every :math:`k > 0`, the :math:`k \times k` matrices of polynomials
+with coefficients in that ring again form a ring.
+Thus we can calculate with structures just as easily as we can calculate
+with their elements.
+This means that algebraic structures lead dual lives in mathematics,
+as containers for collections of objects and as objects in their own right.
+A proof assistant has to accommodate this dual role.
+
+When dealing with elements of a type that has an algebraic structure
+associated with it,
+a proof assistant needs to recognize the structure and find the relevant
+definitions, theorems, and notation.
+All this should sound like a lot of work, and it is.
+But Lean uses a small collection of fundamental mechanisms to
+carry out these tasks.
+The goal of this section is to explain these mechanisms and show you
+how to use them.
+
+The first ingredient is almost too obvious to mention:
+formally speaking, algebraic structures are structures in the sense
+of the :numref:`section_structures`.
+An algebraic structure is a specification of a bundle of data satisfying
+some axiomatic hypotheses, and we saw in the :numref:`section_structures` that
+this is exactly what the ``structure`` command is designed to accommodate.
+It's a marriage made in heaven!
+
+Given a data type ``α``, we can define the group structure on ``α``
+as follows.
+EXAMPLES: -/
+-- QUOTE:
+structure group₁ (α : Type*) :=
+(mul: α → α → α)
+(one: α)
+(inv: α → α)
+(mul_assoc : ∀ x y z : α, mul (mul x y) z = mul x (mul y z))
+(mul_one: ∀ x : α, mul x one = x)
+(one_mul: ∀ x : α, mul x one = x)
+(mul_left_inv : ∀ x : α, mul (inv x) x = one)
+-- QUOTE.
+
+-- OMIT: TODO: explain the extends command later, and also redundant inheritance
+/- TEXT:
+Notice that the type ``α`` is a *parameter* in the definition of ``group₁``.
+So you should think of an object ``struc : group₁ α`` as being
+a group structure on ``α``.
+We saw in :numref:`proving_identities_in_algebraic_structures`
+that the counterpart ``mul_right_inv`` to ``mul_left_inv``
+follows from the other group axioms, so there is no need
+to add it to the definition.
+
+This definition of a group is similar to the definition of ``group`` in
+mathlib,
+and we have chosen the name ``group₁`` to distinguish our version.
+If you write ``#check group`` and ctrl-click on the definition,
+you will see that the mathlib version of ``group`` is defined to
+extend another structure; we will explain how to do that later.
+If you type ``#print group`` you will also see that the mathlib
+version of ``group`` has a number of extra fields.
+For reasons we will explain later, sometimes it is useful to add
+redundant information to a structure,
+so that there are additional fields for objects and functions
+that can be defined from the core
+data. Don't worry about that for now.
+Rest assured that our simplified version ``group₁`` is
+morally the same as the definition of a group that mathlib uses.
+
+It is sometimes useful to bundle
+the type together with the structure, and mathlib also
+contains a definition of a ``Group`` structure that is equivalent to
+the following:
+EXAMPLES: -/
+-- QUOTE:
+structure Group₁ :=
+(α : Type*)
+(str : group₁ α)
+-- QUOTE.
+
+/- TEXT:
+The mathlib version is found in ``algebra.category.Group.basic``,
+and you can ``#check`` it if you add this to the imports at the
+beginning of the examples file.
+
+For reasons that will become clearer below, it is more often
+useful to keep the type ``α`` separate from the structure ``group α``.
+We refer to the two objects together as a *partially bundled structure*,
+since the representation combines most, but not all, of the components
+into one structure. It is common in mathlib
+to use capital roman letters like ``G`` for a type
+when it is used as the carrier type for a group.
+
+Let's construct a group, which is to say, an instance of a ``group₁`` structure.
+For any pair of types ``α`` and ``β``, Mathlib defines the type ``equiv α β``
+of *equivalences* between ``α`` and ``β``.
+Mathlib also defines the suggestive notation ``α ≃ β`` for this type.
+An element ``f : α ≃ β`` is a bijection between ``α`` and ``β``
+represented by four components:
+a function ``f.to_fun`` from ``α`` to ``β``,
+the inverse function ``f.inv`` from ``β`` to ``α``,
+and two properties that specify these functions are indeed inverse
+to one another.
+EXAMPLES: -/
+section
+-- QUOTE:
+variables (α β γ : Type*)
+variables (f : α ≃ β) (g : β ≃ γ)
+
+#check equiv α β
+#check (f.to_fun : α → β)
+#check (f.inv_fun : β → α)
+#check (f.right_inv: ∀ x : β, f (f.inv_fun x) = x)
+#check (f.left_inv: ∀ x : α, f.inv_fun (f x) = x)
+
+#check (equiv.refl α : α ≃ α)
+#check (f.symm : β ≃ α)
+#check (f.trans g : α ≃ γ)
+-- QUOTE.
+
+/- TEXT:
+Notice the creative naming of the last three constructions. We think of the
+identity function ``equiv.refl``, the inverse operation ``equiv.symm``,
+and the composition operation ``equiv.trans`` as explicit evidence
+that ``equiv`` is an equivalence relation.
+
+Notice also that ``f.trans g`` requires composing the forward functions
+in reverse order. Mathlib has declared a *coercion* from ``equiv α β``
+to the function type ``α → β``, so we can omit writing ``.to_fun``
+and have Lean insert it for us.
+EXAMPLES: -/
+-- QUOTE:
+example (x : α) : (f.trans g).to_fun x = g.to_fun (f.to_fun x) := rfl
+
+example (x : α) : (f.trans g) x = g (f x) := rfl
+
+example : (f.trans g : α → γ) = g ∘ f := rfl
+-- QUOTE.
+
+end
+
+/- TEXT:
+Mathlib also defines the type ``perm α`` of equivalences between
+``α`` and itself.
+EXAMPLES: -/
+-- QUOTE:
+example (α : Type*) : equiv.perm α = (α ≃ α) := rfl
+-- QUOTE.
+
+/- TEXT:
+It should be clear that ``perm α`` forms a group under composition
+of equivalences. We orient things so that ``mul f g`` is
+equal to ``g.trans f``, whose forward function is ``f ∘ g``.
+In other words, multiplication is what we ordinarily think of as
+composition of the bijections. Here we define this particular
+group instance:
+EXAMPLES: -/
+-- QUOTE:
+def perm_group {α : Type*} : group₁ (equiv.perm α) :=
+{ mul          := λ f g, equiv.trans g f,
+  one          := equiv.refl α,
+  inv          := equiv.symm,
+  mul_assoc    := λ f g h, (equiv.trans_assoc _ _ _).symm,
+  one_mul      := equiv.trans_refl,
+  mul_one      := equiv.refl_trans,
+  mul_left_inv := equiv.self_trans_symm }
+-- QUOTE.
+
+/- TEXT:
+In fact, mathlib defines exactly this ``group`` structure on ``equiv.perm α``
+in the file ``group_theory.perm.basic``.
+As always, you can hover over the theorems used in the definition of
+``perm_group`` to see their statements,
+and you can jump to their definitions in the original file to learn
+more about how they are implemented.
+
+In ordinary mathematics, we generally think of notation as
+independent of structure.
+For example, we can consider groups :math:`(G_1, \cdot, 1, \cdot^{-1})`,
+:math:`(G_2, \circ, e, i(\cdot))`, and :math:`(G_3, +, 0, -)`.
+In the first case, we write the binary operation as :math:`\cdot`,
+the identity at :math:`1`, and the inverse function as :math:`x \mapsto x^{-1}`.
+In the second and third cases, we use the notational alternatives shown.
+When we formalize the notion of a group in Lean, however,
+the notation is more tightly linked to the structure.
+In Lean, the components of any ``group`` are named
+``mul``, ``one``, and ``inv``,
+and in a moment we will see how multplicative notation is
+set up to refer to them.
+If we want to use additive notation, we instead use an isomorphic structure
+``additive_group``. Its components are named ``add``, ``zero``,
+and ``neg``, and the associated notation is what you would expect it to be.
+
+Recall the type ``point`` that we defined in :numref:`section_structures`,
+and the addition function that we defined there.
+These definitions are reproduced in the examples file that accompanies
+this section.
+As an exercise, define an ``add_group₁`` structure that is similar
+to the ``group₁`` structure we defined above, except that it uses the
+additive naming scheme just described.
+Define negation and a zero on the ``point`` data type,
+and define the ``add_group₁`` structure on ``point``.
+BOTH: -/
+-- QUOTE:
+structure add_group₁ (α : Type*) :=
+/- EXAMPLES:
+sorry
+SOLUTIONS: -/
+(add: α → α → α)
+(zero: α)
+(neg: α → α)
+(add_assoc : ∀ x y z : α, add (add x y) z = add x (add y z))
+(add_zero: ∀ x : α, add x zero = x)
+(zero_add: ∀ x : α, add x zero = x)
+(add_left_neg : ∀ x : α, add (neg x) x = zero)
+-- BOTH:
+
+@[ext] structure point := (x : ℝ) (y : ℝ) (z : ℝ)
+
+namespace point
+
+def add (a b : point) : point := ⟨a.x + b.x, a.y + b.y, a.z + b.z⟩
+
+/- EXAMPLES:
+def neg (a b : point) : point := sorry
+
+def zero : point := sorry
+
+def add_group_point : add_group point := sorry
+SOLUTIONS: -/
+def neg (a : point) : point := ⟨-a.x, -a.y, -a.z⟩
+
+def zero : point := ⟨0, 0, 0⟩
+
+def add_group_point : add_group₁ point :=
+{ add          := point.add,
+  zero         := point.zero,
+  neg          := point.neg,
+  add_assoc    := by { simp [point.add, add_assoc] },
+  add_zero     := by { simp [point.add, point.zero], intro, ext; refl },
+  zero_add     := by { simp [point.add, point.zero], intro, ext; refl },
+  add_left_neg := by { simp [point.add, point.neg, point.zero] } }
+-- BOTH:
+
+end point
+-- QUOTE.
+
+/- TEXT:
+We are making progress.
+Now we know how to define algebraic structures in Lean,
+and we know how to define instances of those structures.
+But we also want to associate notation with structures
+so that we can use it with each instance.
+Moreover, we want to arrange it so that we can define an operation
+on a structure and use it with any particular instance,
+and we want to arrange it so that we can prove a theorem about
+a structure and use it with any instance.
+
+In fact, mathlib is already set up to use generic group notation,
+definitions, and theorems for ``equiv.perm α``.
+EXAMPLES: -/
+section
+-- QUOTE:
+variables {α : Type*} (f g : equiv.perm α) (n : ℕ)
+
+#check f * g
+#check mul_assoc f g g⁻¹
+
+-- group power, defined for any group
+#check g^n
+
+example : f * g * (g⁻¹) = f :=
+by { rw [mul_assoc, mul_right_inv, mul_one] }
+
+example : f * g * (g⁻¹) = f := mul_inv_cancel_right f g
+
+example {α : Type*} (f g : equiv.perm α) : g.symm.trans (g.trans f) = f :=
+mul_inv_cancel_right f g
+-- QUOTE.
+
+end
+
+/- TEXT:
+You can check that this is not the case for the additive group structure
+on ``point`` that we asked you to define above.
+Our task now is to understand that magic that goes on under the hood
+in order to make the examples for ``equiv.perm α`` work the way they do.
+
+The issue is that Lean needs to be able to *find* the relevant
+notation and the implicit group structure,
+using the information that is found in the expressions that we type.
+Simiarly, when we write ``x + y`` with expressions ``x`` and ``y``
+that have type ``ℝ``, Lean needs to interpret the ``+``
+symbol as the relevant addition function on the reals.
+It also has to recognize the type ``ℝ`` as an instance of a commutative ring,
+so that all the definitions and theorems for a commutative ring are available.
+For another example,
+continuity is defined in Lean relative to any two topological spaces.
+When we have ``f : ℝ → ℂ`` and we write ``continuous f``, Lean has to find the
+relevant topologies on ``ℝ`` and ``ℂ``.
+
+The magic is achieved with a combination of three things.
+
+#. *Logic.* A definition that should be interpreted in any group takes, as
+   arguments, the type of the group and the group structure as arguments.
+   Similarly, a theorem
+   that holds of any group begins with universal quantifiers over
+   the type the of group and the group structure.
+
+#. *Implicit arguments.* The arguments for the type and the structure
+   are generally left implicit, so that we do not have to write them
+   or see them in the Lean information window. Lean fills the
+   information in for us silently.
+
+#. *Type class inference.* Also known as *class inference*,
+   this is a simple but powerful mechanism
+   that enables us to register information for Lean to use later on.
+   When Lean is called on to fill in implicit arguments to a
+   definition, theorem, or piece of notation,
+   it can make use of information that has been registered.
+
+Whereas an annotation ``(grp : group G)`` tells Lean that it should
+expect to be given that argument explicitly and the annotation
+``{grp : group G}`` tells Lean that it should try to figure it out
+from contextual cues in the expression,
+the annotation ``[grp : group G]`` tells Lean that the corresponding
+argument should be synthesized using type class inference.
+Since the whole point to the use of such arguments is that
+we generally do not need to refer to them explicitly,
+Lean allows us to write ``[group G]`` and leave the name anonymous.
+You have probably already noticed that Lean chooses names like ``_inst_1``
+automatically.
+When we use the square-bracket annotation with the ``variables`` command,
+then as long as the variables are still in scope,
+Lean automatically adds the argument ``[group G]`` to any definition or
+theorem that mentions ``G``.
+
+How do we register the information that Lean needs to use to carry
+out the search?
+Returning to our group example, we need only make two changes.
+First, instead of using the ``structure`` command to define the group structure,
+we use the keyword ``class`` to indicate that it is a candidate
+for class inference.
+Second, instead of defining particular instances with ``def``,
+we use the keyword ``instance`` to register the particular instance with
+Lean. As with the names of class variables, we are allowed to leave the
+name of an instance definition anonymous,
+since in general we intend Lean to find it and put it to use
+without troubling us with the details.
+EXAMPLES: -/
+-- QUOTE:
+class group₂ (α : Type*) :=
+(mul: α → α → α)
+(one: α)
+(inv: α → α)
+(mul_assoc : ∀ x y z : α, mul (mul x y) z = mul x (mul y z))
+(mul_one: ∀ x : α, mul x one = x)
+(one_mul: ∀ x : α, mul x one = x)
+(mul_left_inv : ∀ x : α, mul (inv x) x = one)
+
+instance {α : Type*} : group₂ (equiv.perm α) :=
+{ mul          := λ f g, equiv.trans g f,
+  one          := equiv.refl α,
+  inv          := equiv.symm,
+  mul_assoc    := λ f g h, (equiv.trans_assoc _ _ _).symm,
+  one_mul      := equiv.trans_refl,
+  mul_one      := equiv.refl_trans,
+  mul_left_inv := equiv.self_trans_symm }
+-- QUOTE.
+
+/- TEXT:
+The following illustrates their use.
+EXAMPLES: -/
+-- QUOTE:
+#check @group₂.mul
+
+def my_square {α : Type*} [group₂ α] (x : α) := group₂.mul x x
+
+#check @my_square
+
+section
+variables {β : Type*} (f g : equiv.perm β)
+
+example : group₂.mul f g = g.trans f := rfl
+
+example : my_square f = f.trans f := rfl
+
+end
+-- QUOTE.
+
+/- TEXT:
+The ``#check`` command shows that ``group₂.mul`` has an implicit argument
+``[group₂ α]`` that we expect to be found by class inference,
+where ``α`` is the type of the arguments to ``group₂.mul``.
+In other words, ``{α : Type*}`` is the implicit argument for the type
+of the group elements and ``[group₂ α]`` is the implicit argument for the
+group structure on ``α``.
+Similarly, when we define a generic squaring function ``my_square``
+for ``group₂``, we use an implicit argument ``{α : Type*}`` for
+the type of the elements and an implicit argument ``[group₂ α]`` for
+the ``group₂`` structure.
+
+In the first example,
+when we write ``group₂.mul f g``, the type of ``f`` and ``g``
+tells Lean that in the argument ``α`` to ``group₂.mul``
+has to be instantiated to ``equiv.perm β``.
+That means that Lean has to find an element of ``group₂ (equiv.perm β)``.
+The previous ``instance`` declaration tells Lean exactly how to do that.
+Problem solved!
+
+This simple mechanism for registering information so that Lean can find it
+when it needs it is remarkably useful.
+Here is one way it comes up.
+In Lean's foundation, a data type ``α`` may be empty.
+In a number of applications, however, it is useful to know that a
+type has at least one element.
+For example, the function ``list.head``, which returns the first
+element of a list, can return the default value when the list is empty.
+To make that work, the Lean library defines a class ``inhabited α``,
+which does nothing more than store a default value.
+We can show that the ``point`` type is an instance:
+EXAMPLES: -/
+-- QUOTE:
+instance : inhabited point := { default := ⟨0, 0, 0⟩ }
+
+#check (default : point)
+
+example : ([] : list point).head = default := rfl
+-- QUOTE.
+
+/- TEXT:
+The class inference mechanism is also used for generic notation.
+The expression ``x + y`` is an abbreviation for ``has_add.add x y``
+where---you guessed it---``has_add α`` is a class that stores
+a binary function on ``α``.
+Writing ``x + y`` tells Lean to find a registered instance of ``[has_add.add α]``
+and use the corresponding function.
+Below, we register the addition function for ``point``.
+EXAMPLES: -/
+-- QUOTE:
+instance : has_add point := { add := point.add }
+
+section
+variables x y : point
+
+#check x + y
+
+example : x + y = point.add x y := rfl
+
+end
+-- QUOTE.
+
+/- TEXT:
+In this way, we can assign the notation ``+`` to binary operations on other
+types as well.
+
+But we can do even better. We have seen that ``*`` can be used in any
+group, ``+`` can be used in any additive group, and both can be used in
+any ring.
+When we define a new instance of a ring in Lean,
+we don't have to define ``+`` and ``*`` for that instance,
+because Lean knows that these are defined for every ring.
+We can use this method to specify notation for our ``group₂`` class:
+EXAMPLES: -/
+-- QUOTE:
+instance has_mul_group₂ {α : Type*} [group₂ α] : has_mul α := ⟨group₂.mul⟩
+
+instance has_one_group₂ {α : Type*} [group₂ α] : has_one α := ⟨group₂.one⟩
+
+instance has_inv_group₂ {α : Type*} [group₂ α] : has_inv α := ⟨group₂.inv⟩
+
+section
+variables {α : Type*} (f g : equiv.perm α)
+
+#check f * 1 * g⁻¹
+
+def foo: f * 1 * g⁻¹ = g.symm.trans ((equiv.refl α).trans f) := rfl
+
+end
+-- QUOTE.
+
+/- TEXT:
+In this case, we have to supply names for the instances, because
+Lean has a hard time coming up with good defaults.
+What makes this approach work is that Lean carries out a recursive search.
+According to the instances we have declared, Lean can find an instance of
+``has_mul (equiv.perm α)`` by finding an
+instance of ``group₂ (equiv.perm α)``, and it can find an instance of
+``group₂ (equiv.perm α)`` because we have provided one.
+Lean is capable of finding these two facts and chaining them together.
+
+The example we have just given is dangerous, because Lean's
+library also has an instance of ``group (equiv.perm α)``, and
+multiplication is defined on any group.
+So it is ambiguous as to which instance is found.
+In fact, Lean favors more recent declarations unless you explicitly
+specify a different priority.
+Also, there is another way to tell Lean that one structure is an
+instance of another, using the ``extends`` keyword.
+This is how ``mathlib`` specifies that, for example,
+every commutative ring is a ring.
+You can find more information in a
+`section on class inference <https://leanprover.github.io/theorem_proving_in_lean/type_classes.html#managing-type-class-inference>`_ in *Theorem Proving in Lean*.
+
+In general, it is a bad idea to specify a value of
+``*`` for an instance of an algebraic structure that already has
+the notation defined.
+Redefining the notion of ``group`` in Lean is an artificial example.
+In this case, however, both interpretations of the group notation unfold to
+``equiv.trans``, ``equiv.refl``, and ``equiv.symm``, in the same way.
+
+As a similarly artificial exercise,
+define a class ``add_group₂`` in analogy to ``group₂``.
+Define the usual notation for addition, negation, and zero
+on any ``add_group₂``
+using the classes ``has_add``, ``has_neg``, and ``has_zero``.
+Then show ``point`` is an instance of ``add_group₂``.
+Try it out and make sure that the additive group notation works for
+elements of ``point``.
+BOTH: -/
+-- QUOTE:
+class add_group₂ (α : Type*) :=
+/- EXAMPLES:
+sorry
+-- QUOTE.
+SOLUTIONS: -/
+(add: α → α → α)
+(zero: α)
+(neg: α → α)
+(add_assoc : ∀ x y z : α, add (add x y) z = add x (add y z))
+(add_zero: ∀ x : α, add x zero = x)
+(zero_add: ∀ x : α, add x zero = x)
+(add_left_neg : ∀ x : α, add (neg x) x = zero)
+
+instance has_add_add_group₂ {α : Type*} [add_group₂ α] :
+has_add α := ⟨add_group₂.add⟩
+
+instance has_zero_add_group₂ {α : Type*} [add_group₂ α] :
+has_zero α := ⟨add_group₂.zero⟩
+
+instance has_neg_add_group₂ {α : Type*} [add_group₂ α] :
+has_neg α := ⟨add_group₂.neg⟩
+
+instance : add_group₂ point :=
+{ add          := point.add,
+  zero         := point.zero,
+  neg          := point.neg,
+  add_assoc    := by { simp [point.add, add_assoc] },
+  add_zero     := by { simp [point.add, point.zero], intro, ext; refl },
+  zero_add     := by { simp [point.add, point.zero], intro, ext; refl },
+  add_left_neg := by { simp [point.add, point.neg, point.zero] } }
+
+section
+variables (x y : point)
+
+#check x + -y + 0
+end
+
+/- TEXT:
+It is not a big problem that we have already declared instances
+``has_add``, ``has_neg``, and ``has_zero`` for ``point`` above.
+Once again, the two ways of synthesizing the notation should come up
+with the same answer.
+
+Class inference is subtle, and you have to be careful when using it,
+because it configures automation that invisibly governs the interpretation of
+the expressions we type.
+When used wisely, however, class inference is a powerful tool.
+It is what makes algebraic reasoning possible in Lean.
+TEXT. -/
+

--- a/lean_source/06_Abstract_Algebra/source_02_Algebraic_Structures.lean
+++ b/lean_source/06_Abstract_Algebra/source_02_Algebraic_Structures.lean
@@ -194,7 +194,7 @@ into one structure. It is common in mathlib
 to use capital roman letters like ``G`` for a type
 when it is used as the carrier type for a group.
 
-Let's construct a group, which is to say, an instance of a ``group₁`` structure.
+Let's construct a group, which is to say, an element of the ``group₁`` type.
 For any pair of types ``α`` and ``β``, Mathlib defines the type ``equiv α β``
 of *equivalences* between ``α`` and ``β``.
 Mathlib also defines the suggestive notation ``α ≃ β`` for this type.
@@ -255,8 +255,7 @@ It should be clear that ``perm α`` forms a group under composition
 of equivalences. We orient things so that ``mul f g`` is
 equal to ``g.trans f``, whose forward function is ``f ∘ g``.
 In other words, multiplication is what we ordinarily think of as
-composition of the bijections. Here we define this particular
-group instance:
+composition of the bijections. Here we define this group:
 EXAMPLES: -/
 -- QUOTE:
 def perm_group {α : Type*} : group₁ (equiv.perm α) :=

--- a/lean_source/06_Abstract_Algebra/source_02_Algebraic_Structures.lean
+++ b/lean_source/06_Abstract_Algebra/source_02_Algebraic_Structures.lean
@@ -307,7 +307,8 @@ BOTH: -/
 -- QUOTE:
 structure add_group₁ (α : Type*) :=
 /- EXAMPLES:
-sorry
+(add : α → α → α)
+-- fill in the rest
 SOLUTIONS: -/
 (add: α → α → α)
 (zero: α)
@@ -624,7 +625,8 @@ BOTH: -/
 -- QUOTE:
 class add_group₂ (α : Type*) :=
 /- EXAMPLES:
-sorry
+(add : α → α → α)
+-- fill in the rest
 -- QUOTE.
 SOLUTIONS: -/
 (add: α → α → α)

--- a/lean_source/mkall.sh
+++ b/lean_source/mkall.sh
@@ -18,3 +18,4 @@ lean_source/mkdoc.py 05_Number_Theory 01_Irrational_Roots
 lean_source/mkdoc.py 05_Number_Theory 02_Induction_and_Recursion
 lean_source/mkdoc.py 05_Number_Theory 03_Infinitely_Many_Primes
 lean_source/mkdoc.py 06_Abstract_Algebra 01_Structures
+lean_source/mkdoc.py 06_Abstract_Algebra 02_Algebraic_Structures

--- a/lean_source/mkall.sh
+++ b/lean_source/mkall.sh
@@ -17,3 +17,4 @@ lean_source/mkdoc.py 04_Sets_and_Functions 03_The_Schroeder_Bernstein_Theorem
 lean_source/mkdoc.py 05_Number_Theory 01_Irrational_Roots
 lean_source/mkdoc.py 05_Number_Theory 02_Induction_and_Recursion
 lean_source/mkdoc.py 05_Number_Theory 03_Infinitely_Many_Primes
+lean_source/mkdoc.py 06_Abstract_Algebra 01_Structures

--- a/source/06_Abstract_Algebra.rst
+++ b/source/06_Abstract_Algebra.rst
@@ -25,3 +25,4 @@ For more technical detail, you can consult `Theorem Proving in Lean <https://lea
 and a paper by Anne Baanen, `Use and abuse of instance parameters in the Lean mathematical library <https://arxiv.org/abs/2202.01629>`_.
 
 .. include:: 06_Abstract_Algebra/01_Structures.inc
+.. include:: 06_Abstract_Algebra/02_Algebraic_Structures.inc

--- a/source/06_Abstract_Algebra.rst
+++ b/source/06_Abstract_Algebra.rst
@@ -1,0 +1,27 @@
+.. _abstract_algebra:
+
+Abstract Algebra
+================
+
+Modern mathematics makes essential use of algebraic
+structures,
+which encapsulate patterns that can be instantiated in
+multiple settings.
+The subject provides various ways of defining such structures and
+constructing particular instances.
+
+Lean therefore provides corresponding ways of
+defining structures formally and working with them.
+You have already seen examples of algebraic structures in Lean,
+such as rings and lattices, which were discussed in
+:numref:`Chapter %s <basics>`.
+This chapter will explain the mysterious square bracket annotations
+that you saw there,
+``[ring α]`` and ``[lattice α]``.
+It will also show you how to define and use
+algebraic structures on your own.
+
+For more technical detail, you can consult `Theorem Proving in Lean <https://leanprover.github.io/theorem_proving_in_lean/>`_,
+and a paper by Anne Baanen, `Use and abuse of instance parameters in the Lean mathematical library <https://arxiv.org/abs/2202.01629>`_.
+
+.. include:: 06_Abstract_Algebra/01_Structures.inc

--- a/source/index.rst
+++ b/source/index.rst
@@ -12,6 +12,7 @@ Mathematics in Lean
    03_Logic
    04_Sets_and_Functions
    05_Number_Theory
+   06_Abstract_Algebra
 
 .. toctree::
    :hidden:

--- a/user_repo/README.md
+++ b/user_repo/README.md
@@ -3,9 +3,9 @@
 This tutorial depends on Lean, VS Code, and mathlib.
 You can find the textbook both online and in this repository
 in
-[html format](https://avigad.github.io/mathematics_in_lean/)
+[html format](https://leanprover-community.github.io/mathematics_in_lean/)
 or as a
-[pdf document](https://avigad.github.io/mathematics_in_lean/mathematics_in_lean.pdf).
+[pdf document](https://leanprover-community.github.io/mathematics_in_lean/mathematics_in_lean.pdf).
 The book is designed to be read as you
 work through examples and exercises,
 using a copy of this repository on your computer.
@@ -44,7 +44,7 @@ This will update the `src` folder, but will not change `my_files`.
 ## To use this repository with Gitpod
 
 If you have a Gitpod account or are willing to sign up for one,
-just point your browser to [https://gitpod.io/#/https://github.com/avigad/mathematics_in_lean](https://gitpod.io/#/https://github.com/avigad/mathematics_in_lean).
+just point your browser to [https://gitpod.io/#/https://github.com/leanprover-community/mathematics_in_lean](https://gitpod.io/#/https://github.com/leanprover-community/mathematics_in_lean).
 This creates a virtual machine in the cloud,
 and installs Lean and mathlib.
 It then presents you with a VS Code window, running in a virtual


### PR DESCRIPTION
This is a start on chapter 6, which introduces abstract algebra. The opening section deals only with structures. The next section will introduce type class inference, and begin to explain how this is used to build hierarchy of structures.