### PR TITLE
Fix a minor prose error in the text.

### DIFF
--- a/MIL/C02_Basics/Source_S01_Calculating.lean
+++ b/MIL/C02_Basics/Source_S01_Calculating.lean
@@ -219,7 +219,7 @@ TEXT. -/
 section
 
 -- QUOTE:
-variable (a b c d e f g : ℝ)
+variable (a b c d e f : ℝ)
 
 example (h : a * b = c * d) (h' : e = f) : a * (b * e) = c * (d * f) := by
   rw [h', ← mul_assoc, h, mul_assoc]

--- a/MIL/C02_Basics/Source_S01_Calculating.lean
+++ b/MIL/C02_Basics/Source_S01_Calculating.lean
@@ -1,6 +1,3 @@
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Real.Basic
-
 /- TEXT:
 Calculating
 -----------
@@ -35,6 +32,8 @@ Let's try out ``rw``.
 TEXT. -/
 -- An example.
 -- QUOTE:
+import Mathlib.Data.Real.Basic
+
 example (a b c : ℝ) : a * b * c = b * (a * c) := by
   rw [mul_comm a b]
   rw [mul_assoc b a c]


### PR DESCRIPTION
The quoted example was referencing an import, but the import was not part of the rendered document (and happened to be repeated for some reason).

Also remove a variable that's declared but never used.