### PR TITLE
chore: bump mathlib

### DIFF
--- a/MIL/C06_Structures/S03_Building_the_Gaussian_Integers.lean
+++ b/MIL/C06_Structures/S03_Building_the_Gaussian_Integers.lean
@@ -635,7 +635,7 @@ instance : EuclideanDomain gaussInt :=
     quotient_zero := fun x ↦ by
       simp [div_def, norm, Int.div']
       rfl
-    r := Measure (Int.natAbs ∘ norm)
+    r := (measure (Int.natAbs ∘ norm)).1
     r_wellFounded := (measure (Int.natAbs ∘ norm)).2
     remainder_lt := natAbs_norm_mod_lt
     mul_left_not_lt := not_norm_mul_left_lt_norm }

--- a/MIL/C09_Differential_Calculus/S01_Elementary_Differential_Calculus.lean
+++ b/MIL/C09_Differential_Calculus/S01_Elementary_Differential_Calculus.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv
+import Mathlib.Analysis.Calculus.Deriv.Pow
 import Mathlib.Analysis.Calculus.MeanValue
 
 open Set Filter
@@ -89,7 +90,7 @@ open Set
 
 example {f : ℝ → ℝ} {a b : ℝ} (hab : a < b) (hfc : ContinuousOn f (Icc a b)) (hfI : f a = f b) :
     ∃ c ∈ Ioo a b, deriv f c = 0 :=
-  exists_deriv_eq_zero f hab hfc hfI
+  exists_deriv_eq_zero hab hfc hfI
 -- QUOTE.
 
 /- TEXT:

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -8,26 +8,32 @@
     "name": "proofwidgets",
     "inputRev?": "v0.0.11"}},
   {"git":
+   {"url": "https://github.com/mhuisi/lean4-cli.git",
+    "subDir?": null,
+    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
+    "name": "Cli",
+    "inputRev?": "nightly"}},
+  {"git":
    {"url": "https://github.com/leanprover-community/mathlib4",
     "subDir?": null,
-    "rev": "88e129706828e01b7622d6635af1ca6667e25bac",
+    "rev": "758b7d6b19adfc8a0d12be3eafb48507e2e859e5",
     "name": "mathlib",
     "inputRev?": "master"}},
   {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "c71f94e34c1cda52eef5c93dc9da409ab2727420",
+    "rev": "ae84bd82cca324dc958583d6f1ae08429877dcb0",
     "name": "Qq",
     "inputRev?": "master"}},
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "ca73109cc40837bc61df8024c9016da4b4f99d4c",
+    "rev": "f04538ab6ad07642368cf11d2702acc0a9b4bcee",
     "name": "aesop",
     "inputRev?": "master"}},
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "e68aa8f5fe47aad78987df45f99094afbcb5e936",
+    "rev": "dff883c55395438ae2a5c65ad5ddba084b600feb",
     "name": "std",
     "inputRev?": "main"}}]}

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2023-06-20
+leanprover/lean4:nightly-2023-07-12


### PR DESCRIPTION
In this mathlib version, `lake exe cache get` uses `leantar`, which helps with cache corruption. See https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/an.20error for the motivation.

The relevant upstream PRs are leanprover-community/mathlib4#5944 and leanprover/lean4#2275.

(A patched-up version of the output repository is at https://github.com/leanprover-community/mathematics_in_lean/pull/9 for testing purposes, but I will close the PR there once it serves no debugging purpose.)