### PR TITLE
Fix gitpod setup

### DIFF
--- a/.docker/gitpod/Dockerfile
+++ b/.docker/gitpod/Dockerfile
@@ -27,9 +27,6 @@ RUN . ~/.profile && elan toolchain install $(curl https://raw.githubusercontent.
 
 ENV PATH="/home/gitpod/.local/bin:/home/gitpod/.elan/bin:${PATH}"
 
-# install scripts
-RUN pip3 install -r scripts/requirements.txt
-
 # fix the infoview when the container is used on gitpod:
 ENV VSCODE_API_VERSION="1.50.0"
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,4 +6,5 @@ vscode:
     - leanprover.lean4
 
 tasks:
+  - init: pip3 install -r scripts/requirements.txt
   - init: lake exe cache get


### PR DESCRIPTION
As with all untested code, this didn't work properly. The docker file did not have access to the `requirements.txt`.

Tested by visiting https://gitpod.io/#https://github.com/avigad/mathematics_in_lean_source/pull/108 and verifying the container now loads.