### PR TITLE
Copy across the build flags from mathlib 

### DIFF
--- a/MIL/C07_Hierarchies/S03_Subobjects.lean
+++ b/MIL/C07_Hierarchies/S03_Subobjects.lean
@@ -131,7 +131,7 @@ instance [Group G] (H : Subgroup₁ G) : Group H :=
   inv := fun x ↦ ⟨x⁻¹, H.inv_mem x.property⟩
   mul_left_inv := fun x ↦ SetCoe.ext (mul_left_inv (x : G)) }
 
-class SubgroupClass₁ (S : Type*) (G : Type) [Group G] [SetLike S G]
+class SubgroupClass₁ (S : Type) (G : Type) [Group G] [SetLike S G]
     extends SubmonoidClass₁ S G  : Prop where
   inv_mem : ∀ (s : S) {a : G}, a ∈ s → a⁻¹ ∈ s
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,13 +1,21 @@
 import Lake
 open Lake DSL
 
-package mil {
-  -- add package configuration options here
-}
+def moreServerArgs := #[
+  "-Dpp.unicode.fun=true", -- pretty-prints `fun a ↦ b`
+  -- this is set in mathlib, but the exercises are nicer to read without it
+  -- "-DautoImplicit=false",
+  "-DrelaxedAutoImplicit=false"
+]
+
+-- These settings only apply during `lake build`, but not in VSCode editor.
+def moreLeanArgs := moreServerArgs
+
+package mil where
+  moreServerArgs := moreServerArgs
 
 @[default_target]
-lean_lib MIL {
-  -- add library configuration options here
-}
+lean_lib MIL where
+  moreLeanArgs := moreLeanArgs
 
 require mathlib from git "https://github.com/leanprover-community/mathlib4"@"master"


### PR DESCRIPTION
For now we do not copy across the `autoImplicit` flag, as this would require changing the exercises.
It might still be worth doing this for a consistent experience with MIL vs mathlib contributions, but I will leave that for someone else to decide.

Depends on #109