### PR TITLE
Fix minor error in the book

### DIFF
--- a/MIL/C02_Basics/S05_Proving_Facts_about_Algebraic_Structures.lean
+++ b/MIL/C02_Basics/S05_Proving_Facts_about_Algebraic_Structures.lean
@@ -334,10 +334,10 @@ using only properties of rings, partial orders, and the facts
 enumerated in the last two examples:
 TEXT. -/
 -- QUOTE:
-example : a ≤ b → 0 ≤ b - a := by
+example (h : a ≤ b) : 0 ≤ b - a := by
   sorry
 
-example : 0 ≤ b - a → a ≤ b := by
+example (h: 0 ≤ b - a) : a ≤ b := by
   sorry
 
 example (h : a ≤ b) (h' : 0 ≤ c) : a * c ≤ b * c := by
@@ -345,13 +345,11 @@ example (h : a ≤ b) (h' : 0 ≤ c) : a * c ≤ b * c := by
 -- QUOTE.
 
 -- SOLUTIONS:
-theorem aux1 : a ≤ b → 0 ≤ b - a := by
-  intro h
+theorem aux1 (h : a ≤ b) : 0 ≤ b - a := by
   rw [← sub_self a, sub_eq_add_neg, sub_eq_add_neg, add_comm, add_comm b]
   apply add_le_add_left h
 
-theorem aux2 : 0 ≤ b - a → a ≤ b := by
-  intro h
+theorem aux2 (h : 0 ≤ b - a) : a ≤ b := by
   rw [← add_zero a, ← sub_add_cancel b a, add_comm (b - a)]
   apply add_le_add_left h
 

--- a/MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean
+++ b/MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean
@@ -221,7 +221,7 @@ example (hfa : FnLb f a) (hgb : FnLb g b) : FnLb (fun x ↦ f x + g x) (a + b) :
 example (nnf : FnLb f 0) (nng : FnLb g 0) : FnLb (fun x ↦ f x * g x) 0 :=
   sorry
 
-example (hfa : FnUb f a) (hfb : FnUb g b) (nng : FnLb g 0) (nna : 0 ≤ a) :
+example (hfa : FnUb f a) (hgb : FnUb g b) (nng : FnLb g 0) (nna : 0 ≤ a) :
     FnUb (fun x ↦ f x * g x) (a * b) :=
   sorry
 -- QUOTE.
@@ -239,12 +239,12 @@ example (nnf : FnLb f 0) (nng : FnLb g 0) : FnLb (fun x ↦ f x * g x) 0 := by
   apply nnf
   apply nng
 
-example (hfa : FnUb f a) (hfb : FnUb g b) (nng : FnLb g 0) (nna : 0 ≤ a) :
+example (hfa : FnUb f a) (hgb : FnUb g b) (nng : FnLb g 0) (nna : 0 ≤ a) :
     FnUb (fun x ↦ f x * g x) (a * b) := by
   intro x
   apply mul_le_mul
   apply hfa
-  apply hfb
+  apply hgb
   apply nng
   apply nna
 

--- a/MIL/C04_Sets_and_Functions/S02_Functions.lean
+++ b/MIL/C04_Sets_and_Functions/S02_Functions.lean
@@ -150,7 +150,7 @@ example : f ⁻¹' u \ f ⁻¹' v ⊆ f ⁻¹' (u \ v) := by
 example : f '' s ∩ v = f '' (s ∩ f ⁻¹' v) := by
   sorry
 
-example : f '' (s ∩ f ⁻¹' u) ⊆ f '' s ∪ u := by
+example : f '' (s ∩ f ⁻¹' u) ⊆ f '' s ∩ u := by
   sorry
 
 example : s ∩ f ⁻¹' u ⊆ f ⁻¹' (f '' s ∩ u) := by


### PR DESCRIPTION
Fix the following errors:

- `C02_Basics/S05_Proving_Facts_about_Algebraic_Structures.lean`:
  Two exercises are stated with type like `a ≤ b → 0 ≤ b - a`, but at
  this point, the `intro` tactic has not been introduced yet. Change it
  to `(h : a ≤ b) : 0 ≤ b - a` to match the style of other example.

- `C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean`:
  `FnUb g b` should have been named `hgb` but not `hfb`.

- `C04_Sets_and_Functions/S02_Functions.lean`:
  The correct theorem should be `f '' (s ∩ f ⁻¹' u) ⊆ f '' s ∩ u`, not
  `f '' (s ∩ f ⁻¹' u) ⊆ f '' s ∪ u`.
