### PR TITLE
make autoImplicit opt-in

### DIFF
--- a/MIL/C03_Logic/S02_The_Existential_Quantifier.lean
+++ b/MIL/C03_Logic/S02_The_Existential_Quantifier.lean
@@ -2,6 +2,8 @@
 import MIL.Common
 import Mathlib.Data.Real.Basic
 
+set_option autoImplicit true
+
 namespace C03S02
 
 /- TEXT:

--- a/MIL/C07_Hierarchies/S01_Basics.lean
+++ b/MIL/C07_Hierarchies/S01_Basics.lean
@@ -2,6 +2,8 @@ import MIL.Common
 import Mathlib.Algebra.BigOperators.Ring
 import Mathlib.Data.Real.Basic
 
+set_option autoImplicit true
+
 /- TEXT:
 .. _section_hierarchies_basics:
 

--- a/MIL/C07_Hierarchies/S02_Morphisms.lean
+++ b/MIL/C07_Hierarchies/S02_Morphisms.lean
@@ -1,6 +1,8 @@
 import MIL.Common
 import Mathlib.Topology.Instances.Real
 
+set_option autoImplicit true
+
 /- TEXT:
 .. _section_hierarchies_morphisms:
 

--- a/MIL/C07_Hierarchies/S03_Subobjects.lean
+++ b/MIL/C07_Hierarchies/S03_Subobjects.lean
@@ -1,6 +1,7 @@
 import MIL.Common
 import Mathlib.GroupTheory.QuotientGroup
 
+set_option autoImplicit true
 
 /- TEXT:
 .. _section_hierarchies_subobjects:

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -3,8 +3,7 @@ open Lake DSL
 
 def moreServerArgs := #[
   "-Dpp.unicode.fun=true", -- pretty-prints `fun a ↦ b`
-  -- this is set in mathlib, but the exercises are nicer to read without it
-  -- "-DautoImplicit=false",
+  "-DautoImplicit=false",
   "-DrelaxedAutoImplicit=false"
 ]
 


### PR DESCRIPTION
This matches the stance taken by mathlib; it doesn't ban autoImplicit completely, but it does force files to acknowledge they are using it (of which there are only four).

This probably isn't the end of this story; I would recommend following up with a further PR (tracked by #115) to either:
* Change these files to not use `autoImplicit`s at all
* Update the explanatory text to explain their usage 