### PR TITLE
Run `lake update` to fix build error

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -12,7 +12,7 @@
   {"git":
    {"url": "https://github.com/mhuisi/lean4-cli.git",
     "subDir?": null,
-    "rev": "5a858c32963b6b19be0d477a30a1f4b6c120be7e",
+    "rev": "21dac2e9cc7e3cf7da5800814787b833e680b2fd",
     "opts": {},
     "name": "Cli",
     "inputRev?": "nightly",
@@ -20,7 +20,7 @@
   {"git":
    {"url": "https://github.com/leanprover-community/mathlib4",
     "subDir?": null,
-    "rev": "6b391efa697c6b0e8590cac08cc1c3ec02974702",
+    "rev": "01fd4ae9d7d2500add74deb5c5b74db763a38f34",
     "opts": {},
     "name": "mathlib",
     "inputRev?": "master",
@@ -28,7 +28,7 @@
   {"git":
    {"url": "https://github.com/gebner/quote4",
     "subDir?": null,
-    "rev": "81cc13c524a68d0072561dbac276cd61b65872a6",
+    "rev": "e75daed95ad1c92af4e577fea95e234d7a8401c1",
     "opts": {},
     "name": "Qq",
     "inputRev?": "master",
@@ -36,7 +36,7 @@
   {"git":
    {"url": "https://github.com/JLimperg/aesop",
     "subDir?": null,
-    "rev": "086c98bb129ca856381d4414dc0afd6e3e4ae2ef",
+    "rev": "1a0cded2be292b5496e659b730d2accc742de098",
     "opts": {},
     "name": "aesop",
     "inputRev?": "master",
@@ -44,7 +44,7 @@
   {"git":
    {"url": "https://github.com/leanprover/std4",
     "subDir?": null,
-    "rev": "b5f7bd40d2162fe148e585543f284a5d8cc0ef26",
+    "rev": "101f1d041068be39093633e4ebf95f8c6fae2240",
     "opts": {},
     "name": "std",
     "inputRev?": "main",


### PR DESCRIPTION
I cloned the repo, ran `lake build`, and got this error:
```
[285/1893] Building Mathlib.Tactic.ToAdditive
error: > LEAN_PATH=./lake-packages/proofwidgets/build/lib:./lake-packages/Cli/build/lib:./lake-packages/mathlib/build/lib:./build/lib:./lake-packages/Qq/build/lib:./lake-packages/aesop/build/lib:./lake-packages/std/build/lib LD_LIBRARY_PATH=./lake-packages/aesop/build/lib /nix/store/2pff8j43a2ncq77gnxaa81rh5ql4y7r4-lean-stage1/bin/lean ./lake-packages/aesop/././Aesop/Util/Basic.lean -R ./lake-packages/aesop/./. -o ./lake-packages/aesop/build/lib/Aesop/Util/Basic.olean -i ./lake-packages/aesop/build/lib/Aesop/Util/Basic.ilean -c ./lake-packages/aesop/build/ir/Aesop/Util/Basic.c
error: stdout:
./lake-packages/aesop/././Aesop/Util/Basic.lean:94:20: error: unknown identifier 'getConst?'
./lake-packages/aesop/././Aesop/Util/Basic.lean:96:15: error: invalid field notation, type is not of the form (C ...) where C is a constant
  info
has type
  ?m.2849 decl
./lake-packages/aesop/././Aesop/Util/Basic.lean:98:22: error: invalid dotted identifier notation, expected type is not of the form (... → C ...) where C is a constant
  ?m.2923
./lake-packages/aesop/././Aesop/Util/Basic.lean:100:24: error: invalid dotted identifier notation, expected type is not of the form (... → C ...) where C is a constant
  ?m.3043
error: external command `/nix/store/2pff8j43a2ncq77gnxaa81rh5ql4y7r4-lean-stage1/bin/lean` exited with code 1
```
Hence the build failed and my editor couldn't show me goals.

After I ran `lake update` and removed `lake-packages`, `lake build` worked