### PR TITLE
Feat: enable codespaces in user repo

### DIFF
--- a/user_repo_source/.devcontainer/Dockerfile
+++ b/user_repo_source/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/base:jammy
+
+USER vscode
+WORKDIR /home/vscode
+
+RUN curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
+
+ENV PATH="/home/vscode/.elan/bin:${PATH}"

--- a/user_repo_source/.devcontainer/devcontainer.json
+++ b/user_repo_source/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "MIL dev container",
+
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+
+  "onCreateCommand": "echo \"Downloading the Lean 4 mathematical library...\" && lake exe cache get! && lake build +MIL.Common && echo \"Finished setup! Open a file using the Explorer in the top-left of your screen.\"",
+
+  "customizations": {
+    "vscode" : {
+      "extensions" : [ "leanprover.lean4" ]
+    }
+  }
+}

--- a/user_repo_source/README.md
+++ b/user_repo_source/README.md
@@ -59,7 +59,7 @@ This requires a Github account. If you are signed in to Github, click here:
 
 <a href='https://codespaces.new/leanprover-community/mathematics_in_lean' target="_blank" rel="noreferrer noopener"><img src='https://github.com/codespaces/badge.svg' alt='Open in GitHub Codespaces' style='max-width: 100%;'></a>
 
-* Make sure the Machine type is `4-core`, and then press `Create codespace`.
+* Make sure the Machine type is `4-core`, and then press `Create codespace` (this might take a few minutes).
 
 ## To use this repository with Gitpod
 

--- a/user_repo_source/README.md
+++ b/user_repo_source/README.md
@@ -9,7 +9,7 @@ or as a
 The book is designed to be read as you
 work through examples and exercises,
 using a copy of this repository on your computer.
-Alternatively, you can use Gitpod to run Lean and VS Code in the cloud.
+Alternatively, you can use Github Codespaces or Gitpod to run Lean and VS Code in the cloud.
 
 This version of *Mathematics in Lean* is designed for [Lean 4](https://leanprover.github.io/) and
 [Mathlib](https://github.com/leanprover-community/mathlib4).
@@ -52,9 +52,18 @@ followed by `lake exe cache get` inside the `mathematics_in_lean` folder.
 (This assumes that you have not changed the contents of the `MIL` folder,
 which is why we suggested making a copy.)
 
+## To use this repository with Github Codespaces
+
+If you have trouble installing Lean, you can use Lean directly in your browser using Github codespaces.
+This requires a Github account. If you are signed in to Github, click here:
+
+<a href='https://codespaces.new/leanprover-community/mathematics_in_lean' target="_blank" rel="noreferrer noopener"><img src='https://github.com/codespaces/badge.svg' alt='Open in GitHub Codespaces' style='max-width: 100%;'></a>
+
+* Make sure the Machine type is `4-core`, and then press `Create codespace`.
 
 ## To use this repository with Gitpod
 
+Gitpod is an alternative to Github Codespaces, but is a little less convenient, since it requires you to verify your phone number.
 If you have a Gitpod account or are willing to sign up for one,
 just point your browser to [https://gitpod.io/#/https://github.com/leanprover-community/mathematics_in_lean](https://gitpod.io/#/https://github.com/leanprover-community/mathematics_in_lean).
 This creates a virtual machine in the cloud,


### PR DESCRIPTION
I think Codespaces is a lot friendlier for new users: Gitpod requires new users to verify their phone number (and I believe Codespaces also gives new users more hours, but I'm not sure).

This code worked on two of my other repositories, (see e.g. [here](https://github.com/fpvandoorn/HausdorffSchoolLean)) but it's probably good to test it anyway.


Note: I just ran into a problem where opening a file in codespaces (in another repo) caused it to start recompiling mathlib. Closing and re-opening codespaces solved that issue.