### PR TITLE
Use `open scoped` not `local instance`

### DIFF
--- a/MIL/C08_Groups_and_Rings/S01_Groups.lean
+++ b/MIL/C08_Groups_and_Rings/S01_Groups.lean
@@ -424,11 +424,11 @@ Let us finish this introduction to subgroups in Mathlib with two very classical 
 Lagrange theorem states the cardinality of a subgroup of a finite group divides the cardinality of
 the group. Sylow's first theorem is a famous partial converse to Lagrange's theorem.
 
-Since this corner of Mathlib is partly set up to allow computation, we need to tell
-Lean to use nonconstructive logic, using the following ``attribute`` command.
+While this corner of Mathlib is partly set up to allow computation, we can tell
+Lean to use nonconstructive logic anyway using the following ``open scoped`` command.
 BOTH: -/
 -- QUOTE:
-attribute [local instance 10] setFintype Classical.propDecidable
+open scoped Classical
 
 open Fintype
 -- EXAMPLES:


### PR DESCRIPTION
`open scoped Classical` means the same thing anyway, but is at least more idiomatic and easier to search for.

Of course I still think it's a bad idea to teach it at all, but that's a problem for another PR!