### PR TITLE
Update S04_Conjunction_and_Iff.lean correct reference to obtain

### DIFF
--- a/MIL/C03_Logic/S04_Conjunction_and_Iff.lean
+++ b/MIL/C03_Logic/S04_Conjunction_and_Iff.lean
@@ -76,8 +76,7 @@ example {x y : ℝ} : x ≤ y ∧ x ≠ y → ¬y ≤ x :=
 -- QUOTE.
 
 /- TEXT:
-In analogy to the ``obtain`` tactic, which we used with the existential
-quantifier, there is also a pattern-matching ``have``:
+In analogy to the ``obtain`` tactic, there is also a pattern-matching ``have``:
 TEXT. -/
 -- QUOTE:
 example {x y : ℝ} (h : x ≤ y ∧ x ≠ y) : ¬y ≤ x := by


### PR DESCRIPTION
It is not true that obtain was used with the existential quantifier, so delete "which we used with the existential quantifier,"