### PR TITLE
Fix typo to define Group₁ by extending Inv₁

### DIFF
--- a/MIL/C07_Hierarchies/S01_Basics.lean
+++ b/MIL/C07_Hierarchies/S01_Basics.lean
@@ -256,7 +256,7 @@ class Inv₁ (α : Type) where
 @[inherit_doc]
 postfix:max "⁻¹" => Inv₁.inv
 
-class Group₁ (G : Type) extends Monoid₁ G, Inv G where
+class Group₁ (G : Type) extends Monoid₁ G, Inv₁ G where
   inv_dia : ∀ a : G, a⁻¹ ⋄ a = 𝟙
 -- QUOTE.
 


### PR DESCRIPTION
... instead of the Inv class from mathlib4.