### PR TITLE
Fix minor typo in S02_Overview.lean

### DIFF
--- a/MIL/C01_Introduction/S02_Overview.lean
+++ b/MIL/C01_Introduction/S02_Overview.lean
@@ -148,7 +148,7 @@ tactic proofs are often easier and quicker to write than
 proof terms.
 There isn't a sharp distinction between the two:
 tactic proofs can be inserted in proof terms,
-as we did with the phrase ``by rw [hk, mul_left_comm]`` in the example above.
+as we did with the phrase ``by rw [hk, mul_add]`` in the example above.
 We will also see that, conversely,
 it is often useful to insert a short proof term in the middle of a tactic proof.
 That said, in this book, our emphasis will be on the use of tactics.


### PR DESCRIPTION
(Issue: https://github.com/avigad/mathematics_in_lean_source/issues/189) Fix a minor typo - the example refers to `mul_add`, not `mul_left_comm`. 

## Testing

```
lake exe cache get
lake build

pip install sphinx-rtd-theme==1.2.0rc4
scripts/mkall.py
make html
```

Locally succeeded (on OSX), and the html looks good.