### PR TITLE
Use Π instead of ∀ for statement of Chinese Remainder Theorem

### DIFF
--- a/MIL/C08_Groups_and_Rings/S02_Rings.lean
+++ b/MIL/C08_Groups_and_Rings/S02_Rings.lean
@@ -199,7 +199,7 @@ open BigOperators PiNotation
 
 -- EXAMPLES:
 example {ι : Type*} [Fintype ι] (a : ι → ℕ) (coprime : ∀ i j, i ≠ j → (a i).Coprime (a j)) :
-    ZMod (∏ i, a i) ≃+* ∀ i, ZMod (a i) :=
+    ZMod (∏ i, a i) ≃+* Π i, ZMod (a i) :=
   ZMod.prodEquivPi a coprime
 -- QUOTE.
 


### PR DESCRIPTION
See discussion in: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Mathematics.20in.20Lean.2C.20CRT.20-.20Notation.20confusion