### PR TITLE
Naming convention suggests replacing the type name `gaussInt` with `G…

### DIFF
--- a/MIL/C06_Structures/S03_Building_the_Gaussian_Integers.lean
+++ b/MIL/C06_Structures/S03_Building_the_Gaussian_Integers.lean
@@ -23,7 +23,7 @@ representing a Gaussian integer as a pair of integers, which we think of as the
 BOTH: -/
 -- QUOTE:
 @[ext]
-structure gaussInt where
+structure GaussInt where
   re : ℤ
   im : ℤ
 -- QUOTE.
@@ -42,22 +42,22 @@ be a square root of :math:`-1`. Thus we want
 
 This explains the definition of ``Mul`` below.
 BOTH: -/
-namespace gaussInt
+namespace GaussInt
 
 -- QUOTE:
-instance : Zero gaussInt :=
+instance : Zero GaussInt :=
   ⟨⟨0, 0⟩⟩
 
-instance : One gaussInt :=
+instance : One GaussInt :=
   ⟨⟨1, 0⟩⟩
 
-instance : Add gaussInt :=
+instance : Add GaussInt :=
   ⟨fun x y ↦ ⟨x.re + y.re, x.im + y.im⟩⟩
 
-instance : Neg gaussInt :=
+instance : Neg GaussInt :=
   ⟨fun x ↦ ⟨-x.re, -x.im⟩⟩
 
-instance : Mul gaussInt :=
+instance : Mul GaussInt :=
   ⟨fun x y ↦ ⟨x.re * y.re - x.im * y.im, x.re * y.im + x.im * y.re⟩⟩
 -- QUOTE.
 
@@ -74,19 +74,19 @@ It is often useful to have an explicit name for the definitions, for example,
 to use with ``simp`` and ``rewrite``.
 BOTH: -/
 -- QUOTE:
-theorem zero_def : (0 : gaussInt) = ⟨0, 0⟩ :=
+theorem zero_def : (0 : GaussInt) = ⟨0, 0⟩ :=
   rfl
 
-theorem one_def : (1 : gaussInt) = ⟨1, 0⟩ :=
+theorem one_def : (1 : GaussInt) = ⟨1, 0⟩ :=
   rfl
 
-theorem add_def (x y : gaussInt) : x + y = ⟨x.re + y.re, x.im + y.im⟩ :=
+theorem add_def (x y : GaussInt) : x + y = ⟨x.re + y.re, x.im + y.im⟩ :=
   rfl
 
-theorem neg_def (x : gaussInt) : -x = ⟨-x.re, -x.im⟩ :=
+theorem neg_def (x : GaussInt) : -x = ⟨-x.re, -x.im⟩ :=
   rfl
 
-theorem mul_def (x y : gaussInt) :
+theorem mul_def (x y : GaussInt) :
     x * y = ⟨x.re * y.re - x.im * y.im, x.re * y.im + x.im * y.re⟩ :=
   rfl
 -- QUOTE.
@@ -97,56 +97,56 @@ parts, and to declare them to the simplifier.
 BOTH: -/
 -- QUOTE:
 @[simp]
-theorem zero_re : (0 : gaussInt).re = 0 :=
+theorem zero_re : (0 : GaussInt).re = 0 :=
   rfl
 
 @[simp]
-theorem zero_im : (0 : gaussInt).im = 0 :=
+theorem zero_im : (0 : GaussInt).im = 0 :=
   rfl
 
 @[simp]
-theorem one_re : (1 : gaussInt).re = 1 :=
+theorem one_re : (1 : GaussInt).re = 1 :=
   rfl
 
 @[simp]
-theorem one_im : (1 : gaussInt).im = 0 :=
+theorem one_im : (1 : GaussInt).im = 0 :=
   rfl
 
 @[simp]
-theorem add_re (x y : gaussInt) : (x + y).re = x.re + y.re :=
+theorem add_re (x y : GaussInt) : (x + y).re = x.re + y.re :=
   rfl
 
 @[simp]
-theorem add_im (x y : gaussInt) : (x + y).im = x.im + y.im :=
+theorem add_im (x y : GaussInt) : (x + y).im = x.im + y.im :=
   rfl
 
 @[simp]
-theorem neg_re (x : gaussInt) : (-x).re = -x.re :=
+theorem neg_re (x : GaussInt) : (-x).re = -x.re :=
   rfl
 
 @[simp]
-theorem neg_im (x : gaussInt) : (-x).im = -x.im :=
+theorem neg_im (x : GaussInt) : (-x).im = -x.im :=
   rfl
 
 @[simp]
-theorem mul_re (x y : gaussInt) : (x * y).re = x.re * y.re - x.im * y.im :=
+theorem mul_re (x y : GaussInt) : (x * y).re = x.re * y.re - x.im * y.im :=
   rfl
 
 @[simp]
-theorem mul_im (x y : gaussInt) : (x * y).im = x.re * y.im + x.im * y.re :=
+theorem mul_im (x y : GaussInt) : (x * y).im = x.re * y.im + x.im * y.re :=
   rfl
 -- QUOTE.
 
 /- TEXT:
 It is now surprisingly easy to show that the Gaussian integers are an instance
 of a commutative ring. We are putting the structure concept to good use.
-Each particular Gaussian integer is an instance of the ``gaussInt`` structure,
-whereas the type ``gaussInt`` itself, together with the relevant operations, is an
+Each particular Gaussian integer is an instance of the ``GaussInt`` structure,
+whereas the type ``GaussInt`` itself, together with the relevant operations, is an
 instance of the ``CommRing`` structure. The ``CommRing`` structure, in turn,
 extends the notational structures ``Zero``, ``One``, ``Add``,
 ``Neg``, and ``Mul``.
 
-If you type ``instance : CommRing gaussInt := _``, click on the light bulb
+If you type ``instance : CommRing GaussInt := _``, click on the light bulb
 that appears in VS Code, and then ask Lean to fill in a skeleton for the
 structure definition, you will see a scary number of entries.
 Jumping to the definition of the structure, however, shows that many of the
@@ -162,7 +162,7 @@ the integers. Note that we could easily avoid repeating all this code, but
 this is not the topic of the current discussion.
 BOTH: -/
 -- QUOTE:
-instance instCommRing : CommRing gaussInt where
+instance instCommRing : CommRing GaussInt where
   zero := 0
   one := 1
   add := (· + ·)
@@ -212,11 +212,11 @@ instance instCommRing : CommRing gaussInt where
 -- QUOTE.
 
 @[simp]
-theorem sub_re (x y : gaussInt) : (x - y).re = x.re - y.re :=
+theorem sub_re (x y : GaussInt) : (x - y).re = x.re - y.re :=
   rfl
 
 @[simp]
-theorem sub_im (x y : gaussInt) : (x - y).im = x.im - y.im :=
+theorem sub_im (x y : GaussInt) : (x - y).im = x.im - y.im :=
   rfl
 
 /- TEXT:
@@ -226,13 +226,13 @@ to saying that the zero is not equal to the one. Since some common theorems
 depend on that fact, we may as well establish it now.
 BOTH: -/
 -- QUOTE:
-instance : Nontrivial gaussInt := by
+instance : Nontrivial GaussInt := by
   use 0, 1
-  rw [Ne, gaussInt.ext_iff]
+  rw [Ne, GaussInt.ext_iff]
   simp
 -- QUOTE.
 
-end gaussInt
+end GaussInt
 
 /- TEXT:
 We will now show that the Gaussian integers have an important additional
@@ -436,19 +436,19 @@ SOLUTIONS: -/
 -- BOTH:
 /- TEXT:
 We will put all the remaining definitions and theorems in this section
-in the ``gaussInt`` namespace.
+in the ``GaussInt`` namespace.
 First, we define the ``norm`` function and ask you to establish
 some of its properties.
 The proofs are all short.
 BOTH: -/
-namespace gaussInt
+namespace GaussInt
 
 -- QUOTE:
-def norm (x : gaussInt) :=
+def norm (x : GaussInt) :=
   x.re ^ 2 + x.im ^ 2
 
 @[simp]
-theorem norm_nonneg (x : gaussInt) : 0 ≤ norm x := by
+theorem norm_nonneg (x : GaussInt) : 0 ≤ norm x := by
 /- EXAMPLES:
   sorry
 SOLUTIONS: -/
@@ -456,15 +456,15 @@ SOLUTIONS: -/
   apply sq_nonneg
 
 -- BOTH:
-theorem norm_eq_zero (x : gaussInt) : norm x = 0 ↔ x = 0 := by
+theorem norm_eq_zero (x : GaussInt) : norm x = 0 ↔ x = 0 := by
 /- EXAMPLES:
   sorry
 SOLUTIONS: -/
-  rw [norm, sq_add_sq_eq_zero, gaussInt.ext_iff]
+  rw [norm, sq_add_sq_eq_zero, GaussInt.ext_iff]
   rfl
 
 -- BOTH:
-theorem norm_pos (x : gaussInt) : 0 < norm x ↔ x ≠ 0 := by
+theorem norm_pos (x : GaussInt) : 0 < norm x ↔ x ≠ 0 := by
 /- EXAMPLES:
   sorry
 SOLUTIONS: -/
@@ -472,7 +472,7 @@ SOLUTIONS: -/
   simp [norm_nonneg]
 
 -- BOTH:
-theorem norm_mul (x y : gaussInt) : norm (x * y) = norm x * norm y := by
+theorem norm_mul (x y : GaussInt) : norm (x * y) = norm x * norm y := by
 /- EXAMPLES:
   sorry
 SOLUTIONS: -/
@@ -485,18 +485,18 @@ SOLUTIONS: -/
 Next we define the conjugate function:
 BOTH: -/
 -- QUOTE:
-def conj (x : gaussInt) : gaussInt :=
+def conj (x : GaussInt) : GaussInt :=
   ⟨x.re, -x.im⟩
 
 @[simp]
-theorem conj_re (x : gaussInt) : (conj x).re = x.re :=
+theorem conj_re (x : GaussInt) : (conj x).re = x.re :=
   rfl
 
 @[simp]
-theorem conj_im (x : gaussInt) : (conj x).im = -x.im :=
+theorem conj_im (x : GaussInt) : (conj x).im = -x.im :=
   rfl
 
-theorem norm_conj (x : gaussInt) : norm (conj x) = norm x := by simp [norm]
+theorem norm_conj (x : GaussInt) : norm (conj x) = norm x := by simp [norm]
 -- QUOTE.
 
 /- TEXT:
@@ -515,7 +515,7 @@ respectively. Here the numerators are the real and imaginary parts of
 of :math:`c + di`.
 BOTH: -/
 -- QUOTE:
-instance : Div gaussInt :=
+instance : Div GaussInt :=
   ⟨fun x y ↦ ⟨Int.div' (x * conj y).re (norm y), Int.div' (x * conj y).im (norm y)⟩⟩
 -- QUOTE.
 
@@ -526,14 +526,14 @@ theorems ``div_def`` and
 ``mod_def`` so that we can use them with ``simp`` and ``rewrite``.
 BOTH: -/
 -- QUOTE:
-instance : Mod gaussInt :=
+instance : Mod GaussInt :=
   ⟨fun x y ↦ x - y * (x / y)⟩
 
-theorem div_def (x y : gaussInt) :
+theorem div_def (x y : GaussInt) :
     x / y = ⟨Int.div' (x * conj y).re (norm y), Int.div' (x * conj y).im (norm y)⟩ :=
   rfl
 
-theorem mod_def (x y : gaussInt) : x % y = x - y * (x / y) :=
+theorem mod_def (x y : GaussInt) : x % y = x - y * (x / y) :=
   rfl
 -- QUOTE.
 
@@ -567,7 +567,7 @@ This messy calculation is carried out in the next proof. We encourage you
 to step through the details and see if you can find a nicer argument.
 BOTH: -/
 -- QUOTE:
-theorem norm_mod_lt (x : gaussInt) {y : gaussInt} (hy : y ≠ 0) :
+theorem norm_mod_lt (x : GaussInt) {y : GaussInt} (hy : y ≠ 0) :
     (x % y).norm < y.norm := by
   have norm_y_pos : 0 < norm y := by rwa [norm_pos]
   have H1 : x % y * conj y = ⟨Int.mod' (x * conj y).re (norm y), Int.mod' (x * conj y).im (norm y)⟩
@@ -597,10 +597,10 @@ natural numbers and back to the integers does not change the value.
 The second one re-expresses the fact that the norm is decreasing.
 BOTH: -/
 -- QUOTE:
-theorem coe_natAbs_norm (x : gaussInt) : (x.norm.natAbs : ℤ) = x.norm :=
+theorem coe_natAbs_norm (x : GaussInt) : (x.norm.natAbs : ℤ) = x.norm :=
   Int.natAbs_of_nonneg (norm_nonneg _)
 
-theorem natAbs_norm_mod_lt (x y : gaussInt) (hy : y ≠ 0) :
+theorem natAbs_norm_mod_lt (x y : GaussInt) (hy : y ≠ 0) :
     (x % y).norm.natAbs < y.norm.natAbs := by
   apply Int.ofNat_lt.1
   simp only [Int.coe_natAbs, abs_of_nonneg, norm_nonneg]
@@ -612,7 +612,7 @@ We also need to establish the second key property of the norm function
 on a Euclidean domain.
 BOTH: -/
 -- QUOTE:
-theorem not_norm_mul_left_lt_norm (x : gaussInt) {y : gaussInt} (hy : y ≠ 0) :
+theorem not_norm_mul_left_lt_norm (x : GaussInt) {y : GaussInt} (hy : y ≠ 0) :
     ¬(norm (x * y)).natAbs < (norm x).natAbs := by
   apply not_lt_of_ge
   rw [norm_mul, Int.natAbs_mul]
@@ -635,8 +635,8 @@ and in that case, the required properties are the theorems
 ``natAbs_norm_mod_lt`` and ``not_norm_mul_left_lt_norm``.
 BOTH: -/
 -- QUOTE:
-instance : EuclideanDomain gaussInt :=
-  { gaussInt.instCommRing with
+instance : EuclideanDomain GaussInt :=
+  { GaussInt.instCommRing with
     quotient := (· / ·)
     remainder := (· % ·)
     quotient_mul_add_remainder_eq :=
@@ -655,8 +655,8 @@ An immediate payoff is that we now know that, in the Gaussian integers,
 the notions of being prime and being irreducible coincide.
 BOTH: -/
 -- QUOTE:
-example (x : gaussInt) : Irreducible x ↔ Prime x :=
+example (x : GaussInt) : Irreducible x ↔ Prime x :=
   PrincipalIdealRing.irreducible_iff_prime
 -- QUOTE.
 
-end gaussInt
+end GaussInt


### PR DESCRIPTION
…aussInt`