### PR TITLE
chore: add extensions.json to prevent pop-up about unnecessary extension

### DIFF
--- a/user_repo_source/.vscode/extensions.json
+++ b/user_repo_source/.vscode/extensions.json
@@ -1,0 +1,15 @@
+// This file prevents VS Code from making unhelpful suggestions about extensions
+// during the initial setup of Mathematics In Lean.
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"leanprover.lean4"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+		"ms-vscode-remote.remote-containers"
+	]
+}


### PR DESCRIPTION
I noticed while helping people do installation this morning that everyone had a pop-up about installing an necessary extension.

This PR copies and pastes the corresponding file from Mathlib, which I think successfully inhibits this pop-up. I haven't re-tested, however.