### PR TITLE
switch proposition names `pge` and `primep` in S01_Sets.lean

### DIFF
--- a/MIL/C04_Sets_and_Functions/S01_Sets.lean
+++ b/MIL/C04_Sets_and_Functions/S01_Sets.lean
@@ -647,8 +647,8 @@ example : (⋃ p ∈ primes, { x | x ≤ p }) = univ := by
   apply eq_univ_of_forall
   intro x
   simp
-  rcases Nat.exists_infinite_primes x with ⟨p, primep, pge⟩
-  use p, pge
+  rcases Nat.exists_infinite_primes x with ⟨p, pge, primep⟩
+  use p, primep
 
 -- BOTH:
 end


### PR DESCRIPTION
Names of propositions `pge` and `primep` don't match when destructing `Nat.exists_infinite_primes`