### PR TITLE
surjectivity of SB function does not require injectivity of f

### DIFF
--- a/MIL/C04_Sets_and_Functions/S03_The_Schroeder_Bernstein_Theorem.lean
+++ b/MIL/C04_Sets_and_Functions/S03_The_Schroeder_Bernstein_Theorem.lean
@@ -312,7 +312,7 @@ In both cases, calling the simplifier with ``simp [sbAux]``
 applies the corresponding defining equation of ``sbAux``.
 BOTH: -/
 -- QUOTE:
-theorem sb_surjective (hf : Injective f) (hg : Injective g) : Surjective (sbFun f g) := by
+theorem sb_surjective (hg : Injective g) : Surjective (sbFun f g) := by
   set A := sbSet f g with A_def
   set h := sbFun f g with h_def
   intro y
@@ -348,7 +348,7 @@ EXAMPLES: -/
 -- QUOTE:
 theorem schroeder_bernstein {f : α → β} {g : β → α} (hf : Injective f) (hg : Injective g) :
     ∃ h : α → β, Bijective h :=
-  ⟨sbFun f g, sb_injective f g hf, sb_surjective f g hf hg⟩
+  ⟨sbFun f g, sb_injective f g hf, sb_surjective f g hg⟩
 -- QUOTE.
 
 -- Auxiliary information


### PR DESCRIPTION
In the proof of surjectivity of `sbFun`, injectivity of `f` is not needed. This eliminates a warning and makes things more symmetric with the proof of injectivity which does not require injectivity of `g`. This might be highlighted in the text as well.