### PR TITLE
Update S04_More_on_Order_and_Divisibility.lean

### DIFF
--- a/MIL/C02_Basics/S04_More_on_Order_and_Divisibility.lean
+++ b/MIL/C02_Basics/S04_More_on_Order_and_Divisibility.lean
@@ -174,7 +174,7 @@ It is an interesting fact that ``min`` distributes over ``max``
 the way that multiplication distributes over addition,
 and vice-versa.
 In other words, on the real numbers, we have the identity
-``min a (max b c) ≤ max (min a b) (min a c)``
+``min a (max b c) = max (min a b) (min a c)``
 as well as the corresponding version with ``max`` and ``min``
 switched.
 But in the next section we will see that this does *not* follow


### PR DESCRIPTION
Fix typo, the identity of min distributing over max and vice versa is an equality but was written as an inequality.