### PR TITLE
use `where` when defining inductive types

### DIFF
--- a/MIL/C05_Elementary_Number_Theory/S02_Induction_and_Recursion.lean
+++ b/MIL/C05_Elementary_Number_Theory/S02_Induction_and_Recursion.lean
@@ -18,7 +18,7 @@ OMIT: -/
 namespace hidden
 
 -- QUOTE:
-inductive Nat
+inductive Nat where
   | zero : Nat
   | succ (n : Nat) : Nat
 -- QUOTE.
@@ -346,7 +346,7 @@ that subtracts one from any nonzero number and fixes zero.
 The function ``pred`` can be defined by a simple instance of recursion.
 BOTH: -/
 -- QUOTE:
-inductive MyNat
+inductive MyNat where
   | zero : MyNat
   | succ : MyNat → MyNat
 


### PR DESCRIPTION
Lean's prelude and other textbooks such as Functional Programing in Lean and Theorem Proving in Lean all use `where` when defining inductive types, so I guess it's the recommended syntax (?)