### PR TITLE
replace `rw` by `simp`

### DIFF
--- a/MIL/C05_Elementary_Number_Theory/S02_Induction_and_Recursion.lean
+++ b/MIL/C05_Elementary_Number_Theory/S02_Induction_and_Recursion.lean
@@ -239,8 +239,8 @@ EXAMPLES: -/
 -- QUOTE:
 example (n : ℕ) : fac n = ∏ i in range n, (i + 1) := by
   induction' n with n ih
-  · rw [fac, prod_range_zero]
-  rw [fac, ih, prod_range_succ, mul_comm]
+  · simp [fac, prod_range_zero]
+  simp [fac, ih, prod_range_succ, mul_comm]
 -- QUOTE.
 
 /- TEXT:


### PR DESCRIPTION
The text just after the code snippet says

> The fact that we include `mul_comm` as a simplification rule deserves comment. It should seem dangerous to simplify with the identity `x * y = y * x`, which would ordinarily loop indefinitely.

But the snippet uses `rw` so this doesn't make sense. 