### PR TITLE
Update outdated VS Code command reference

### DIFF
--- a/MIL/C01_Introduction/S01_Getting_Started.lean
+++ b/MIL/C01_Introduction/S01_Getting_Started.lean
@@ -55,11 +55,11 @@ At that point, you can open the textbook in a side panel in VS Code as follows:
 
 1. Type ``ctrl-shift-P`` (``command-shift-P`` in macOS).
 
-2. Type ``Lean 4: Open Documentation View`` in the bar that appears, and then
+2. Type ``Lean 4: Docs: Show Documentation Resources`` in the bar that appears, and then
    press return. (You can press return to select it as soon as it is highlighted
    in the menu.)
 
-3. In the window that opens, click on ``Open documentation of current project``.
+3. In the window that opens, click on ``Mathematics in Lean``.
 
 Alternatively, you can run Lean and VS Code in the cloud,
 using `Gitpod <https://gitpod.io/>`_.


### PR DESCRIPTION
The Lean 4 VS Code extension now uses a different command and a VS Code SimpleBrowser to display online documentation.