### PR TITLE
Update S01_Elementary_Integration.lean

### DIFF
--- a/MIL/C11_Integration_and_Measure_Theory/S01_Elementary_Integration.lean
+++ b/MIL/C11_Integration_and_Measure_Theory/S01_Elementary_Integration.lean
@@ -3,8 +3,6 @@ import Mathlib.MeasureTheory.Integral.IntervalIntegral
 import Mathlib.Analysis.SpecialFunctions.Integrals
 import Mathlib.Analysis.Convolution
 
-local macro_rules | `($x ^ $y) => `(HPow.hPow $x $y)
-
 open Set Filter
 
 open Topology Filter


### PR DESCRIPTION
This was necessary in older versions of Lean 4, but is not needed any more.