### PR TITLE
Typos in Chapter 06

### DIFF
--- a/MIL/C06_Structures/S01_Structures.lean
+++ b/MIL/C06_Structures/S01_Structures.lean
@@ -161,7 +161,7 @@ same; the only difference is that we use anonymous constructor notation
 in the second.
 Although it is sometimes convenient to define functions this way, and structural eta-reduction makes
 this alternative definitionally equivalent, it can make things less convenient in later proofs.
-In particular, ``rw [addAlt]`` leaves us with a messier goal view containing a `match` statement.
+In particular, ``rw [addAlt]`` leaves us with a messier goal view containing a ``match`` statement.
 EXAMPLES: -/
 -- QUOTE:
 def addAlt : Point → Point → Point

--- a/MIL/C06_Structures/S01_Structures.lean
+++ b/MIL/C06_Structures/S01_Structures.lean
@@ -161,7 +161,7 @@ same; the only difference is that we use anonymous constructor notation
 in the second.
 Although it is sometimes convenient to define functions this way, and structural eta-reduction makes
 this alternative definitionally equivalent, it can make things less convenient in later proofs.
-In particular, `rw [addAlt]` leaves us with a messier goal view containing a `match` statement.
+In particular, ``rw [addAlt]`` leaves us with a messier goal view containing a `match` statement.
 EXAMPLES: -/
 -- QUOTE:
 def addAlt : Point → Point → Point

--- a/MIL/C06_Structures/S02_Algebraic_Structures.lean
+++ b/MIL/C06_Structures/S02_Algebraic_Structures.lean
@@ -149,7 +149,7 @@ structure Group₁ (α : Type*) where
 
 -- OMIT: TODO: explain the extends command later, and also redundant inheritance
 /- TEXT:
-Notice that the type ``α`` is a *parameter* in the definition of ``group₁``.
+Notice that the type ``α`` is a *parameter* in the definition of ``Group₁``.
 So you should think of an object ``struc : Group₁ α`` as being
 a group structure on ``α``.
 We saw in :numref:`proving_identities_in_algebraic_structures`

--- a/MIL/C06_Structures/S02_Algebraic_Structures.lean
+++ b/MIL/C06_Structures/S02_Algebraic_Structures.lean
@@ -288,7 +288,7 @@ independent of structure.
 For example, we can consider groups :math:`(G_1, \cdot, 1, \cdot^{-1})`,
 :math:`(G_2, \circ, e, i(\cdot))`, and :math:`(G_3, +, 0, -)`.
 In the first case, we write the binary operation as :math:`\cdot`,
-the identity at :math:`1`, and the inverse function as :math:`x \mapsto x^{-1}`.
+the identity as :math:`1`, and the inverse function as :math:`x \mapsto x^{-1}`.
 In the second and third cases, we use the notational alternatives shown.
 When we formalize the notion of a group in Lean, however,
 the notation is more tightly linked to the structure.

--- a/MIL/C06_Structures/S03_Building_the_Gaussian_Integers.lean
+++ b/MIL/C06_Structures/S03_Building_the_Gaussian_Integers.lean
@@ -604,7 +604,7 @@ theorem natAbs_norm_mod_lt (x y : GaussInt) (hy : y ≠ 0) :
     (x % y).norm.natAbs < y.norm.natAbs := by
   apply Int.ofNat_lt.1
   simp only [Int.natCast_natAbs, abs_of_nonneg, norm_nonneg]
-  apply norm_mod_lt x hy
+  exact norm_mod_lt x hy
 -- QUOTE.
 
 /- TEXT:

--- a/MIL/C06_Structures/S03_Building_the_Gaussian_Integers.lean
+++ b/MIL/C06_Structures/S03_Building_the_Gaussian_Integers.lean
@@ -346,9 +346,9 @@ See the file `GaussianInt.lean
 <https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/NumberTheory/Zsqrtd/GaussianInt.lean>`_.
 
 Here we will instead carry out an argument that stays in the integers.
-This illustrates an choice one commonly faces when formalizing mathematics.
+This illustrates a choice one commonly faces when formalizing mathematics.
 Given an argument that requires concepts or machinery that is not already
-in the library, one has two choices: either formalizes the concepts or machinery
+in the library, one has two choices: either formalize the concepts or machinery
 needed, or adapt the argument to make use of concepts and machinery you
 already have.
 The first choice is generally a good investment of time when the results

--- a/MIL/C06_Structures/S03_Building_the_Gaussian_Integers.lean
+++ b/MIL/C06_Structures/S03_Building_the_Gaussian_Integers.lean
@@ -301,7 +301,7 @@ we have :math:`N(xy) = N(x)N(y)`.
 To see that this definition of the norm makes the Gaussian integers a Euclidean
 domain, only the first property is challenging. Suppose
 we want to write :math:`a + bi = (c + di) q + r` for suitable :math:`q`
-and :math:`r`. Treating :math:`a + bi` and :math:`c + di` are complex
+and :math:`r`. Treating :math:`a + bi` and :math:`c + di` as complex
 numbers, carry out the division
 
 .. math::


### PR DESCRIPTION
A bunch of typos in Chapter 6, and a suggestion to replace `apply` by `exact` at the end of `natAbs_norm_mod_lt`