### PR TITLE
Fix "bundles continuous functions" typo and minor `` parsing error

### DIFF
--- a/MIL/C07_Hierarchies/S02_Morphisms.lean
+++ b/MIL/C07_Hierarchies/S02_Morphisms.lean
@@ -52,7 +52,7 @@ BOTH: -/
 example : Continuous (id : ℝ → ℝ) := continuous_id
 -- QUOTE.
 /- TEXT:
-We still have bundles continuous functions, which are convenient for instance to put a topology
+We still have bundles of continuous functions, which are convenient for instance to put a topology
 on a space of continuous functions, but they are not the primary tool to work with continuity.
 
 By contrast, morphisms between monoids (or other algebraic structures) are bundled as in:

--- a/MIL/C08_Groups_and_Rings/S02_Rings.lean
+++ b/MIL/C08_Groups_and_Rings/S02_Rings.lean
@@ -102,7 +102,7 @@ be covered later in a chapter on linear algebra, but this implementation detail 
 safely ignored since most (but not all) relevant lemmas are restated in the special context of
 ideals. But anonymous projection notation won't always work as expected. For instance,
 one cannot replace ``Ideal.Quotient.mk I`` by ``I.Quotient.mk`` in the snippet below because there
-are two ``.``s and so it will parse as ``(Ideal.Quotient I).mk``; but ``Ideal.Quotient`` by itself
+are two ``.``\s and so it will parse as ``(Ideal.Quotient I).mk``; but ``Ideal.Quotient`` by itself
 doesn't exist.
 EXAMPLES: -/
 -- QUOTE:


### PR DESCRIPTION
- `We still have bundles continuous functions` -> `We still have bundles of continuous functions`

- `are two ``.``s and so it will parse` -> `are two ``.``\s and so it will parse as`
The second one here is a bit strange, but rst usually requires a space after ``.
