### PR TITLE
Add MIL.Common import to intro example

### DIFF
--- a/MIL/C01_Introduction/S02_Overview.lean
+++ b/MIL/C01_Introduction/S02_Overview.lean
@@ -20,6 +20,8 @@ These are mathematical objects.
 TEXT. -/
 -- These are pieces of data.
 -- QUOTE:
+import MIL.Common
+
 #check 2 + 2
 
 def f (x : ℕ) :=


### PR DESCRIPTION
I started reading MIL and was confused by the very first example not working.

<img width="906" alt="Screenshot 2025-02-01 at 20 34 33" src="https://github.com/user-attachments/assets/57e38356-c35c-4b1f-a4de-464a1e4a0d9b" />

I pasted this into the Lean file but got this:

<img width="717" alt="Screenshot 2025-02-01 at 20 35 34" src="https://github.com/user-attachments/assets/9c603fde-8294-4f26-8e7b-13300e196353" />

Not saying this is the best possible fix pedagogically...

A few alternative suggestions:

- Could avoid using the shortcut notation until the next chapter
- Could add `import MIL.Common` to `S01_Getting_Started.lean` in the project repo instead to give a hint 