### PR TITLE
Add missing theorems and solutions to C02 S01

### DIFF
--- a/MIL/C02_Basics/S01_Calculating.lean
+++ b/MIL/C02_Basics/S01_Calculating.lean
@@ -351,9 +351,41 @@ example (a b : ℝ) : (a + b) * (a - b) = a ^ 2 - b ^ 2 := by
 #check mul_sub a b c
 #check add_mul a b c
 #check add_sub a b c
+#check sub_add a b c
+#check sub_self a
 #check sub_sub a b c
 #check add_zero a
 -- QUOTE.
+
+end
+
+-- SOLUTIONS:
+
+section
+variable (a b c d : ℝ)
+
+example : (a + b) * (c + d) = a * c + a * d + b * c + b * d := by
+  rw [mul_add]
+  rw [add_mul, add_mul, ← add_assoc]
+  rw [add_assoc (a * c)]
+  rw [add_assoc (a * c) (a * d), add_comm (a * d)]
+
+example : (a + b) * (c + d) = a * c + a * d + b * c + b * d :=
+  calc
+    (a + b) * (c + d) = (a + b) * c + (a + b) * d := by
+      rw [mul_add]
+    _ = a * c + b * c + a * d + b * d := by
+      rw [add_mul, add_mul, ← add_assoc]
+    _ = a * c + (b * c + a * d) + b * d := by
+      rw [add_assoc (a * c)]
+    _ = a * c + a * d + b * c + b * d := by
+      rw [add_assoc (a * c) (a * d), add_comm (a * d)]
+
+example (a b : ℝ) : (a + b) * (a - b) = a ^ 2 - b ^ 2 := by
+  rw [pow_two, pow_two]
+  rw [add_mul, mul_sub, mul_sub, add_sub]
+  rw [mul_comm b]
+  rw [sub_add, sub_self, sub_sub, add_comm, add_zero]
 
 end
 


### PR DESCRIPTION
There's two problems, as reported [here](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/MIL.20S01_calculating.20solutions.20for.20last.20questions/near/494265603) and [here](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Is.20it.20possible.20to.20complete.20MIL.20C02.20S01.20exercise.20as.20stated.3F):

- The list of allowed theorems _seems_ (to me, anyway!) insufficient. Maybe it's possible to solve it with just these (not sure!) but there's also the second problem, which is...
- These exercises are missing solutions. This is frustrating because I don't know if I'm missing something or the book has a mistake.

This PR attempts to fix both issues.

Note I have not verified the book itself compiles locally so the syntax for including solutions (the `-- SOLUTIONS:` thing) is my best guess based on the format used earlier in the file.

Thanks for consideration!