### PR TITLE
chore: avoid deprecated `Quotient.map₂`, `Quotient.out`, `submodule_independent` and `isClosed_ball`

### DIFF
--- a/MIL/C07_Hierarchies/S03_Subobjects.lean
+++ b/MIL/C07_Hierarchies/S03_Subobjects.lean
@@ -216,7 +216,7 @@ instance [CommMonoid M] : HasQuotient M (Submonoid M) where
 def QuotientMonoid.mk [CommMonoid M] (N : Submonoid M) : M → M ⧸ N := Quotient.mk N.Setoid
 
 instance [CommMonoid M] (N : Submonoid M) : Monoid (M ⧸ N) where
-  mul := Quotient.map₂' (· * ·) (by
+  mul := Quotient.map₂ (· * ·) (by
 /- EXAMPLES:
       sorry
 SOLUTIONS: -/

--- a/MIL/C08_Groups_and_Rings/S01_Groups.lean
+++ b/MIL/C08_Groups_and_Rings/S01_Groups.lean
@@ -655,7 +655,7 @@ Recall that elements of this dependent product are pairs ``⟨ω, x⟩`` where t
 EXAMPLES: -/
 -- QUOTE:
 example {G X : Type*} [Group G] [MulAction G X] :
-    X ≃ (ω : orbitRel.Quotient G X) × (orbit G (Quotient.out' ω)) :=
+    X ≃ (ω : orbitRel.Quotient G X) × (orbit G (Quotient.out ω)) :=
   MulAction.selfEquivSigmaOrbits G X
 -- QUOTE.
 

--- a/MIL/C09_Linear_Algebra/S02_Subspaces.lean
+++ b/MIL/C09_Linear_Algebra/S02_Subspaces.lean
@@ -205,7 +205,7 @@ example (U : ι → Submodule K V) (h : DirectSum.IsInternal U) :
 -- If subspaces are in direct sum then they pairwise intersect only at zero.
 example {ι : Type*} [DecidableEq ι] (U : ι → Submodule K V) (h : DirectSum.IsInternal U)
     {i j : ι} (hij : i ≠ j) : U i ⊓ U j = ⊥ :=
-  (h.submodule_independent.pairwiseDisjoint hij).eq_bot
+  (h.submodule_iSupIndep.pairwiseDisjoint hij).eq_bot
 
 -- Those conditions characterize direct sums.
 #check DirectSum.isInternal_submodule_iff_independent_and_iSup_eq_top

--- a/MIL/C10_Topology/S02_Metric_Spaces.lean
+++ b/MIL/C10_Topology/S02_Metric_Spaces.lean
@@ -607,7 +607,7 @@ example [CompleteSpace X] (f : ℕ → Set X) (ho : ∀ n, IsOpen (f n)) (hd : �
     · exact (incl m).trans (Set.inter_subset_left.trans h)
   have yball : ∀ n, y ∈ closedBall (c n) (r n) := by
     intro n
-    refine isClosed_ball.mem_of_tendsto ylim ?_
+    refine isClosed_closedBall.mem_of_tendsto ylim ?_
     refine (Filter.eventually_ge_atTop n).mono fun m hm ↦ ?_
     exact I n m hm (mem_closedBall_self (rpos _).le)
   constructor


### PR DESCRIPTION
```
warning: ././././MIL/C07_Hierarchies/S03_Subobjects.lean:219:9: `Quotient.map₂'` has been deprecated: use `Quotient.map₂` instead
warning: ././././MIL/C08_Groups_and_Rings/S01_Groups.lean:658:48: `Quotient.out'` has been deprecated: use `Quotient.out` instead
warning: ././././MIL/C09_Linear_Algebra/S02_Subspaces.lean:208:3: `DirectSum.IsInternal.submodule_independent` has been deprecated: use `DirectSum.IsInternal.submodule_iSupIndep` instead
warning: ././././MIL/C10_Topology/S02_Metric_Spaces.lean:610:11: `Metric.isClosed_ball` has been deprecated: use `Metric.isClosed_closedBall` instead
```