### PR TITLE
chore: avoid unused variables

### DIFF
--- a/MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean
+++ b/MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean
@@ -346,7 +346,7 @@ the application of the theorem to its arguments.
 TEXT. -/
 -- QUOTE:
 example (mf : Monotone f) (mg : Monotone g) : Monotone fun x ↦ f x + g x :=
-  fun a b aleb ↦ add_le_add (mf aleb) (mg aleb)
+  fun _ _ aleb ↦ add_le_add (mf aleb) (mg aleb)
 -- QUOTE.
 
 /- TEXT:
@@ -378,7 +378,7 @@ example {c : ℝ} (mf : Monotone f) (nnc : 0 ≤ c) : Monotone fun x ↦ c * f x
   apply mf aleb
 
 example {c : ℝ} (mf : Monotone f) (nnc : 0 ≤ c) : Monotone fun x ↦ c * f x :=
-  fun a b aleb ↦ mul_le_mul_of_nonneg_left (mf aleb) nnc
+  fun _ _ aleb ↦ mul_le_mul_of_nonneg_left (mf aleb) nnc
 
 example (mf : Monotone f) (mg : Monotone g) : Monotone fun x ↦ f (g x) := by
   intro a b aleb
@@ -387,7 +387,7 @@ example (mf : Monotone f) (mg : Monotone g) : Monotone fun x ↦ f (g x) := by
   apply aleb
 
 example (mf : Monotone f) (mg : Monotone g) : Monotone fun x ↦ f (g x) :=
-  fun a b aleb ↦ mf (mg aleb)
+  fun _ _ aleb ↦ mf (mg aleb)
 
 /- TEXT:
 Here are some more examples.
@@ -501,7 +501,7 @@ example : s ⊆ s := by
   intro x xs
   exact xs
 
-theorem Subset.refl : s ⊆ s := fun x xs ↦ xs
+theorem Subset.refl : s ⊆ s := fun _ xs ↦ xs
 
 theorem Subset.trans : r ⊆ s → s ⊆ t → r ⊆ t := by
   sorry
@@ -515,7 +515,7 @@ example : r ⊆ s → s ⊆ t → r ⊆ t := by
   apply xr
 
 theorem Subset.transαα : r ⊆ s → s ⊆ t → r ⊆ t :=
-  fun rsubs ssubt x xr ↦ ssubt (rsubs xr)
+  fun rsubs ssubt _ xr ↦ ssubt (rsubs xr)
 
 -- BOTH:
 end

--- a/MIL/C03_Logic/S04_Conjunction_and_Iff.lean
+++ b/MIL/C03_Logic/S04_Conjunction_and_Iff.lean
@@ -157,7 +157,7 @@ example (x y : ℝ) : (∃ z : ℝ, x < z ∧ z < y) → x < y := by
   exact lt_trans xltz zlty
 
 example (x y : ℝ) : (∃ z : ℝ, x < z ∧ z < y) → x < y :=
-  fun ⟨z, xltz, zlty⟩ ↦ lt_trans xltz zlty
+  fun ⟨_, xltz, zlty⟩ ↦ lt_trans xltz zlty
 -- QUOTE.
 
 /- TEXT:

--- a/MIL/C03_Logic/S06_Sequences_and_Convergence.lean
+++ b/MIL/C03_Logic/S06_Sequences_and_Convergence.lean
@@ -105,7 +105,7 @@ The following shows that any constant sequence :math:`a, a, a, \ldots`
 converges.
 BOTH: -/
 -- QUOTE:
-theorem convergesTo_const (a : ℝ) : ConvergesTo (fun x : ℕ ↦ a) a := by
+theorem convergesTo_const (a : ℝ) : ConvergesTo (fun _ : ℕ ↦ a) a := by
   intro ε εpos
   use 0
   intro n nge

--- a/MIL/C04_Sets_and_Functions/S01_Sets.lean
+++ b/MIL/C04_Sets_and_Functions/S01_Sets.lean
@@ -84,7 +84,7 @@ The following example also illustrate the phenomenon:
 TEXT. -/
 -- QUOTE:
 example (h : s ⊆ t) : s ∩ u ⊆ t ∩ u :=
-  fun x ⟨xs, xu⟩ ↦ ⟨h xs, xu⟩
+  fun _ ⟨xs, xu⟩ ↦ ⟨h xs, xu⟩
 -- QUOTE.
 
 /- TEXT:
@@ -211,7 +211,7 @@ the following one-line proof is for you:
 TEXT. -/
 -- QUOTE:
 example : s ∩ t = t ∩ s :=
-  Set.ext fun x ↦ ⟨fun ⟨xs, xt⟩ ↦ ⟨xt, xs⟩, fun ⟨xt, xs⟩ ↦ ⟨xs, xt⟩⟩
+  Set.ext fun _ ↦ ⟨fun ⟨xs, xt⟩ ↦ ⟨xt, xs⟩, fun ⟨xt, xs⟩ ↦ ⟨xs, xt⟩⟩
 -- QUOTE.
 
 /- TEXT:
@@ -244,7 +244,7 @@ example : s ∩ t = t ∩ s :=
     Subset.antisymm sorry sorry
 SOLUTIONS: -/
     Subset.antisymm
-    (fun x ⟨xs, xt⟩ ↦ ⟨xt, xs⟩) fun x ⟨xt, xs⟩ ↦ ⟨xs, xt⟩
+    (fun _ ⟨xs, xt⟩ ↦ ⟨xt, xs⟩) fun _ ⟨xt, xs⟩ ↦ ⟨xs, xt⟩
 -- QUOTE.
 
 -- BOTH:

--- a/MIL/C04_Sets_and_Functions/S02_Functions.lean
+++ b/MIL/C04_Sets_and_Functions/S02_Functions.lean
@@ -217,7 +217,7 @@ example : f '' s \ f '' t ⊆ f '' (s \ t) := by
   · rfl
 
 example : f ⁻¹' u \ f ⁻¹' v ⊆ f ⁻¹' (u \ v) :=
-  fun x ↦ id
+  fun _ ↦ id
 
 example : f '' s ∩ v = f '' (s ∩ f ⁻¹' v) := by
   ext y; constructor
@@ -622,7 +622,7 @@ example : Surjective f ↔ RightInverse (inverse f) f := by
   apply h
 
 example : Surjective f ↔ RightInverse (inverse f) f :=
-  ⟨fun h y ↦ inverse_spec _ (h _), fun h y ↦ ⟨inverse f y, h _⟩⟩
+  ⟨fun h _ ↦ inverse_spec _ (h _), fun h y ↦ ⟨inverse f y, h _⟩⟩
 
 -- BOTH:
 end

--- a/MIL/C05_Elementary_Number_Theory/S02_Induction_and_Recursion.lean
+++ b/MIL/C05_Elementary_Number_Theory/S02_Induction_and_Recursion.lean
@@ -357,7 +357,7 @@ def add : MyNat → MyNat → MyNat
   | x, succ y => succ (add x y)
 
 def mul : MyNat → MyNat → MyNat
-  | x, zero => zero
+  | _, zero => zero
   | x, succ y => add (mul x y) x
 
 theorem zero_add (n : MyNat) : add zero n = n := by

--- a/MIL/C06_Structures/S02_Algebraic_Structures.lean
+++ b/MIL/C06_Structures/S02_Algebraic_Structures.lean
@@ -269,7 +269,7 @@ def permGroup {α : Type*} : Group₁ (Equiv.Perm α)
   mul f g := Equiv.trans g f
   one := Equiv.refl α
   inv := Equiv.symm
-  mul_assoc f g h := (Equiv.trans_assoc _ _ _).symm
+  mul_assoc _ _ _ := (Equiv.trans_assoc _ _ _).symm
   one_mul := Equiv.trans_refl
   mul_one := Equiv.refl_trans
   inv_mul_cancel := Equiv.self_trans_symm
@@ -480,7 +480,7 @@ instance {α : Type*} : Group₂ (Equiv.Perm α) where
   mul f g := Equiv.trans g f
   one := Equiv.refl α
   inv := Equiv.symm
-  mul_assoc f g h := (Equiv.trans_assoc _ _ _).symm
+  mul_assoc _ _ _ := (Equiv.trans_assoc _ _ _).symm
   one_mul := Equiv.trans_refl
   mul_one := Equiv.refl_trans
   inv_mul_cancel := Equiv.self_trans_symm

--- a/MIL/C12_Integration_and_Measure_Theory/S03_Integration.lean
+++ b/MIL/C12_Integration_and_Measure_Theory/S03_Integration.lean
@@ -49,7 +49,7 @@ In that case, their integrals are equal to zero by definition, as is ``(μ s).to
 So in all cases we have the following lemma.
 EXAMPLES: -/
 -- QUOTE:
-example {s : Set α} (c : E) : ∫ x in s, c ∂μ = (μ s).toReal • c :=
+example {s : Set α} (c : E) : ∫ _ in s, c ∂μ = (μ s).toReal • c :=
   setIntegral_const c
 -- QUOTE.
 


### PR DESCRIPTION
```
warning: ././././MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean:349:6: unused variable `a`
warning: ././././MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean:349:8: unused variable `b`
warning: ././././MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean:381:6: unused variable `a`
warning: ././././MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean:381:8: unused variable `b`
warning: ././././MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean:390:6: unused variable `a`
warning: ././././MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean:390:8: unused variable `b`
warning: ././././MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean:504:35: unused variable `x`
warning: ././././MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean:518:18: unused variable `x`
warning: ././././MIL/C03_Logic/S04_Conjunction_and_Iff.lean:160:7: unused variable `z`
warning: ././././MIL/C03_Logic/S06_Sequences_and_Convergence.lean:108:53: unused variable `x`
warning: ././././MIL/C04_Sets_and_Functions/S01_Sets.lean:214:14: unused variable `x`
warning: ././././MIL/C04_Sets_and_Functions/S01_Sets.lean:247:36: unused variable `x`
warning: ././././MIL/C04_Sets_and_Functions/S01_Sets.lean:247:9: unused variable `x`
warning: ././././MIL/C04_Sets_and_Functions/S01_Sets.lean:87:6: unused variable `x`
warning: ././././MIL/C04_Sets_and_Functions/S02_Functions.lean:220:6: unused variable `x`
warning: ././././MIL/C04_Sets_and_Functions/S02_Functions.lean:625:9: unused variable `y`
warning: ././././MIL/C05_Elementary_Number_Theory/S02_Induction_and_Recursion.lean:360:4: unused variable `x`
warning: ././././MIL/C06_Structures/S02_Algebraic_Structures.lean:272:12: unused variable `f`
warning: ././././MIL/C06_Structures/S02_Algebraic_Structures.lean:272:14: unused variable `g`
warning: ././././MIL/C06_Structures/S02_Algebraic_Structures.lean:272:16: unused variable `h`
warning: ././././MIL/C06_Structures/S02_Algebraic_Structures.lean:483:12: unused variable `f`
warning: ././././MIL/C06_Structures/S02_Algebraic_Structures.lean:483:14: unused variable `g`
warning: ././././MIL/C06_Structures/S02_Algebraic_Structures.lean:483:16: unused variable `h`
warning: ././././MIL/C12_Integration_and_Measure_Theory/S03_Integration.lean:52:32: unused variable `x`
```