### PR TITLE
Added sphinx copy button extension for copying codeblocks

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
+sphinx-copybutton
 sphinx-rtd-theme
 regex

--- a/sphinx_source/conf.py
+++ b/sphinx_source/conf.py
@@ -36,6 +36,8 @@ release = 'v4.19.0'
 #     'sphinx.ext.githubpages',
 #     'lean_sphinx']
 
+extensions = ['sphinx_copybutton']
+
 highlight_language = "lean"
 
 # Allows for numerical references to sections


### PR DESCRIPTION
With this change, a button is added to easily copy any code block. The button shows up only when hovering over the code block. See screenshot below for an example.

<img width="716" height="92" alt="image" src="https://github.com/user-attachments/assets/26537f81-02c7-48c0-8ce5-ed315fe968cc" />