### PR TITLE
Fixed typo in Update C08_S01_Basics.lean

### DIFF
--- a/MIL/C08_Hierarchies/S01_Basics.lean
+++ b/MIL/C08_Hierarchies/S01_Basics.lean
@@ -148,7 +148,7 @@ example {α : Type} [Semigroup₁ α] (a b : α) : α := a ⋄ b
 -- QUOTE.
 
 /- TEXT:
-Note this syntax is also available in the ``structure`` command, although it that
+Note this syntax is also available in the ``structure`` command, although in that
 case it fixes only the hurdle of writing fields such as `toDia₁` since there
 is no instance to define in that case.
 


### PR DESCRIPTION
Fixed a small typo:
"although _it_ that case it fixes only the hurdle of writing fields such" ->  "although _in_ that case it fixes only the hurdle of writing fields such"