### PR TITLE
Fix sequencing operator wording

### DIFF
--- a/MIL/C03_Logic/S04_Conjunction_and_Iff.lean
+++ b/MIL/C03_Logic/S04_Conjunction_and_Iff.lean
@@ -180,8 +180,8 @@ example {x y : ℝ} : x ≤ y ∧ x ≠ y → x ≤ y ∧ ¬y ≤ x := by
 -- QUOTE.
 
 /- TEXT:
-In the first example, the semicolon after the ``constructor`` command tells Lean to use the
-``norm_num`` tactic on both of the goals that result.
+In the first example, the ``<;>`` after the ``constructor`` command tells Lean to use
+the ``norm_num`` tactic on both of the goals that result.
 
 In Lean, ``A ↔ B`` is *not* defined to be ``(A → B) ∧ (B → A)``,
 but it could have been,

--- a/MIL/C03_Logic/S05_Disjunction.lean
+++ b/MIL/C03_Logic/S05_Disjunction.lean
@@ -274,7 +274,7 @@ example {m n k : ℕ} (h : m ∣ n ∨ m ∣ k) : m ∣ n * k := by
 /- TEXT:
 See if you can prove the following with a single (long) line.
 Use ``rcases`` to unpack the hypotheses and split on cases,
-and use a semicolon and ``linarith`` to solve each branch.
+and use ``<;> linarith`` to solve each branch.
 TEXT. -/
 -- QUOTE:
 example {z : ℝ} (h : ∃ x y, z = x ^ 2 + y ^ 2 ∨ z = x ^ 2 + y ^ 2 + 1) : z ≥ 0 := by


### PR DESCRIPTION
## Summary
- update the tutorial text to name Lean's `<;>` operator instead of calling it a semicolon
- adjust the related disjunction exercise hint to match the one-line solution shown below it

## Verification
- `rg -n 'semicolon after the ``constructor``|use a semicolon and ``linarith``|``<;>`` after the ``constructor``|``<;> linarith``' MIL\C03_Logic\S04_Conjunction_and_Iff.lean MIL\C03_Logic\S05_Disjunction.lean -S`
- `git diff --check`

I could not run `lake build` locally because `lake` is not installed in this Windows environment.

Fixes #397