### PR TITLE
Don't suggest non-existent eq_symm

### DIFF
--- a/MIL/C02_Basics/S02_Proving_Identities_in_Algebraic_Structures.lean
+++ b/MIL/C02_Basics/S02_Proving_Identities_in_Algebraic_Structures.lean
@@ -289,7 +289,7 @@ theorem zero_mulαα (a : R) : 0 * a = 0 := by
 By now, you should also be able to replace each ``sorry`` in the next
 exercise with a proof,
 still using only facts about rings that we have
-established in this section along with the axiom ``eq_symm``.
+established in this section along with the axiom ``symm``.
 TEXT. -/
 -- QUOTE:
 theorem neg_eq_of_add_eq_zero {a b : R} (h : a + b = 0) : -a = b := by

--- a/MIL/C02_Basics/S02_Proving_Identities_in_Algebraic_Structures.lean
+++ b/MIL/C02_Basics/S02_Proving_Identities_in_Algebraic_Structures.lean
@@ -289,7 +289,7 @@ theorem zero_mulαα (a : R) : 0 * a = 0 := by
 By now, you should also be able to replace each ``sorry`` in the next
 exercise with a proof,
 still using only facts about rings that we have
-established in this section along with the axiom ``symm``.
+established in this section along with the tactic ``symm``.
 TEXT. -/
 -- QUOTE:
 theorem neg_eq_of_add_eq_zero {a b : R} (h : a + b = 0) : -a = b := by

--- a/MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean
+++ b/MIL/C03_Logic/S01_Implication_and_the_Universal_Quantifier.lean
@@ -143,7 +143,7 @@ SOLUTIONS: -/
 /- TEXT:
 Finish the proof using the theorems
 ``abs_mul``, ``mul_le_mul``, ``abs_nonneg``,
-``mul_lt_mul_of_pos_right ``, and ``one_mul``.
+``mul_lt_mul_of_pos_right``, and ``one_mul``.
 Remember that you can find theorems like these using
 Ctrl-space completion (or Cmd-space completion on a Mac).
 Remember also that you can use ``.mp`` and ``.mpr``


### PR DESCRIPTION
This suggestion is misleading as the suggested "eq_symm" doesn't exist in recent mathlib versions, unlike symm.